### PR TITLE
update documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,8 +13,13 @@ Planned features (open for collaboration):
 * Igor Pro help file documentation
 
 # Documentation
-* The *HTML* version of the manual is found [here](https://github.com/t-b/igor-unit-testing-framework/docu/sphinx/html/index.html).
-* The *PDF* version can be downloaded from [here](https://github.com/t-b/igor-unit-testing-framework/docu/manual.pdf).
+
+The documentation can be found
+[here](https://docs.byte-physics.de/igor-unit-testing-framework/). It contains
+a [guided
+tour](https://docs.byte-physics.de/igor-unit-testing-framework/guided-tour.html)
+and an [introduction to the basic
+structure](https://docs.byte-physics.de/igor-unit-testing-framework/basic.html).
 
 # Requirements
 
@@ -45,5 +50,6 @@ make
 This will create a docker container with all the required dependencies and output the manual as pdf to `docu/manual.pdf` and html to the `docu/sphinx/html` subdirectory.
 The documentation is built using [doxygen](http://www.doxygen.org/), a [home-built awk script](https://github.com/t-b/doxygen-filter-ipf/), [breathe](https://github.com/michaeljones/breathe) and [sphinx](http://www.sphinx-doc.org).
 
+[The current documentation can be found on our website.](https://docs.byte-physics.de/igor-unit-testing-framework/)
 # Bug Reporting
 **Please** report all bugs and major/minor annoyances either as an issue here or directly to (thomas \<dot\> braun \<aehht\> byte \<minus\> physics \<dottt\> de)!


### PR DESCRIPTION
the links were hard coded to the compile directory. They should rather
point to the built documentation which is on the byte-physics website.