### PR TITLE
EvaluateRTE: Avoid Igor crash due to wrong printf usage

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -594,7 +594,7 @@ static Function EvaluateRTE(err, errmessage, abortCode, funcName, funcType, proc
 		endif
 	endif
 
-	printf message
+	printf "%s", message
 	systemErr = message
 
 	CheckAbortCondition(abortCode)


### PR DESCRIPTION
Using printf in that way is unsafe as message could hold unescaped "%"
thus leadint to a RTE.

Or to an Igor crash (fixed with the IP8 nightly from today).

Let's use it correctly.

Bug introduced in a7ab54cb (More detailed RTE error message,
2017-03-07).

Closes #15.

Igor should not crash anymore with the test in #15. I could not find another place where we did it wrong.

