### PR TITLE
AfterFileOpenHook: Make it more robust

### DIFF
--- a/procedures/unit-testing-autorun.ipf
+++ b/procedures/unit-testing-autorun.ipf
@@ -62,13 +62,17 @@ static Function AfterFileOpenHook(refNum, file, pathName, type, creator, kind)
 	if(ItemsInList(funcList) == 1)
 		FuncRef AUTORUN_MODE_PROTO f = $StringFromList(0, funcList)
 
-		try
-			err = GetRTError(1)
-			f(); AbortOnRTE
-		catch
-			err = GetRTError(1)
-			print "The run() function aborted with an RTE and this can not be handled."
-		endtry
+		if(UTF_FuncRefIsAssigned(FuncRefInfo(f)))
+			try
+				err = GetRTError(1)
+				f(); AbortOnRTE
+			catch
+				err = GetRTError(1)
+				print "The run() function aborted with an RTE and this can not be handled."
+			endtry
+		else
+			print "The run() function has an invalid signature."
+		endif
 	else
 		print "The requested autorun mode is not possible because the function run() does not exist in ProcGlobal context."
 	endif

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -54,6 +54,19 @@ static Function ClearRTError()
 	variable err = GetRTError(1)
 End
 
+/// @brief Check wether the function reference points to
+/// the prototype function or to an assigned function
+///
+/// Due to Igor Pro limitations you need to pass the function
+/// info from `FuncRefInfo` and not the function reference itself.
+///
+/// @return 0 if pointing to prototype function, 1 otherwise
+Function UTF_FuncRefIsAssigned(funcInfo)
+	string funcInfo
+
+	return NumberByKey("ISPROTO", funcInfo) == 0
+End
+
 /// @brief Return a free text wave with the dimension labels of the
 ///        given dimension of the wave
 static Function/WAVE GetDimLabels(wv, dim)


### PR DESCRIPTION
Since forever we bugged out if the run function aborts or multiple run
functions exist.

Handle both cases gracefully and quit Igor Pro on error as well.