### PR TITLE
Documentation: Don't delete all running container

### DIFF
--- a/docu/Makefile
+++ b/docu/Makefile
@@ -1,4 +1,4 @@
-default: docu-sphinx clean
+default: docu-sphinx
 
 build-docker-doxygen: debian
 	@make -C docker/doxygen
@@ -34,4 +34,4 @@ clean:
 	@scripts/delete_containers.sh
 	@scripts/delete_danglingimages.sh
 
-all: docu-doxygen docu-sphinx clean
+all: docu-doxygen docu-sphinx


### PR DESCRIPTION
This is not wanted on a CI box where multiple docker container are
running.

@ukos-git Maybe this is always getting in the way of the unit test runs?