### PR TITLE
Use Docker Image For Documentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,15 +9,16 @@ stages:
   - deploy
 
 documentation:
-  tags:
-    - macosx, shell
   stage: build
+  tags:
+    - macosx, docker
+  image:
+    name: ${CI_REGISTRY}/internal/docker-sphinx:latest
   script:
-    - cd docu
-    - make
+    - cd docu/sphinx
+    - make html
   artifacts:
     paths:
-      - docu/manual.pdf
       - docu/sphinx/build/html
 
 testing-v7:


### PR DESCRIPTION
The documentation is built directly from a docker container instead of
building the container via make / docker procedure.

Better fix for

  https://github.com/byte-physics/igor-unit-testing-framework/pull/70