### PR TITLE
*_EQUAL_WAVES: Report the EqualWaves mode as string

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -58,6 +58,36 @@ static Function ClearRTError()
 	variable err = GetRTError(1)
 End
 
+/// @brief Convert the mode parameter for `EqualWaves` to a string
+Function/S EqualWavesModeToString(mode)
+	variable mode
+
+	switch(mode)
+		case WAVE_DATA:
+			return "WAVE_DATA"
+		case WAVE_DATA_TYPE:
+			return "WAVE_DATA_TYPE"
+		case WAVE_SCALING:
+			return "WAVE_SCALING"
+		case DATA_UNITS:
+			return "DATA_UNITS"
+		case DIMENSION_UNITS:
+			return "DIMENSION_UNITS"
+		case DIMENSION_LABELS:
+			return "DIMENSION_LABELS"
+		case WAVE_NOTE:
+			return "WAVE_NOTE"
+		case WAVE_LOCK_STATE:
+			return "WAVE_LOCK_STATE"
+		case DATA_FULL_SCALE:
+			return "DATA_FULL_SCALE"
+		case DIMENSION_SIZES:
+			return "DIMENSION_SIZES"
+		default:
+			return "unknown mode"
+	endswitch
+End
+
 /// @brief Check wether the function reference points to
 /// the prototype function or to an assigned function
 ///

--- a/procedures/unit-testing-comparators.ipf
+++ b/procedures/unit-testing-comparators.ipf
@@ -660,7 +660,7 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 #endif
 		endif
 
-		sprintf str, "Assuming equality using mode %03d for waves %s and %s", mode, NameOfWave(wv1), NameOfWave(wv2)
+		sprintf str, "Assuming equality using mode %s for waves %s and %s", EqualWavesModeToString(mode), NameOfWave(wv1), NameOfWave(wv2)
 
 		if(strlen(detailedMsg) > 0)
 			str += "; detailed: " + detailedMsg


### PR DESCRIPTION
This makes it much faster to understand failing tests.