### PR TITLE
fix: GetFullFunctionName prepended the Module Name even if it was pre…

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -684,7 +684,7 @@ static Function/S getFullFunctionName(err, funcName, procName)
 	// 1.) run in the same IM anyway
 	// 2.) FuncRef does not accept that
 
-	return module + "#" + funcName
+	return module + "#" + StringByKey("NAME", infoStr)
 End
 
 /// Prototype for test cases


### PR DESCRIPTION
…sent

The bug is that when GetFullFunctionName was called with a fully qualified
function name then it prepended the Module name again, such that the returned
name was: ModuleName#ModuleName#FunctionName

Now the split name from FunctionInfo is now assembled properly again in all
cases.