### PR TITLE
Autorun: Handle multiple run functions

### DIFF
--- a/procedures/unit-testing-autorun.ipf
+++ b/procedures/unit-testing-autorun.ipf
@@ -59,7 +59,7 @@ static Function AfterFileOpenHook(refNum, file, pathName, type, creator, kind)
 	endif
 
 	funcList = FunctionList("run", ";", "KIND:2,NPARAMS:0,WIN:[ProcGlobal]")
-	if(ItemsInList(funcList) == 1)
+	if(ItemsInList(funcList) >= 1)
 		FuncRef AUTORUN_MODE_PROTO f = $StringFromList(0, funcList)
 
 		if(UTF_FuncRefIsAssigned(FuncRefInfo(f)))


### PR DESCRIPTION
Since IP7 functions can be declared as override and thus we can find
multiple functions called "run".

Let Igor handle figuring out which function to call and just ensure that
we find at least one function.

Broken since forever.