### PR TITLE
TestCaseEnd: Silently ignore non-killable working folder

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -1111,7 +1111,7 @@ static Function TestCaseEnd(testCase, keepDataFolder)
 	endif
 	if (!keepDataFolder)
 		if(SVAR_Exists(workFolder) && DataFolderExists(workFolder))
-			KillDataFolder $workFolder
+			KillDataFolder/Z $workFolder
 		endif
 	endif
 


### PR DESCRIPTION
The following test case

Function MyTest()
  Make data
  Display data
End

and executing it with default flags results in an error in the
TestCaseEnd hook as the workFolder can not be killed, as the displayed
wave still lives in that.

Just ignore the error as we can not do anything else.