### PR TITLE
Added manual deployment job to CI to staging area

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,6 +104,17 @@ testing-v9:
       - tests/JU_*.xml
       - screenshot/*.png
 
+deployment_staging:
+  when: manual
+  tags:
+    - macosx, shell
+  stage: deploy
+  script:
+    - cd docu/sphinx
+    - make deploy_staging
+  dependencies:
+    - documentation
+
 deployment:
   only:
     - master

--- a/docu/sphinx/Makefile
+++ b/docu/sphinx/Makefile
@@ -27,6 +27,9 @@ debug:
 deploy:
 	@lftp -e "mirror --reverse -n -e build/html /igor-unit-testing-framework; bye" byte-physics-docs
 
+deploy_staging:
+	@lftp -e "mirror --reverse -n -e build/html /igor-unit-testing-framework; bye" byte-physics-docs-staging
+
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new


### PR DESCRIPTION
- this allows developers to deploy the Igor UTF incl. docu to a separated
  internal staging area for review.
- the location is defined through the used lftp bookmark in
  /docu/sphinx/Makefile section deploy_staging.