### PR TITLE
Issue109 sorting testcases

### DIFF
--- a/docu/sphinx/source/basic.rst
+++ b/docu/sphinx/source/basic.rst
@@ -45,7 +45,8 @@ Test Suite
 
 A Test Suite is a group of :ref:`Test Cases<TestCase>` which should belong
 together. All :ref:`test functions<TestCase>` are defined in a single
-procedure file. Generally speaking, a Test Suite is equal to a procedure file.
+procedure file, :cpp:func:`RunTest` calls them from top to bottom. Generally speaking,
+a Test Suite is equal to a procedure file.
 Therefore tests suites can not be nested, although multiple test suites can be
 run with one command by supplying a list to the parameter :code:`procWinList` in
 :cpp:func:`RunTest`.

--- a/internal_dev/testcase_order.ipf
+++ b/internal_dev/testcase_order.ipf
@@ -1,0 +1,82 @@
+﻿#pragma TextEncoding = "UTF-8"
+#pragma rtGlobals=3		// Use modern global access method and strict wave access.
+#pragma ModuleName=SortingTestcases
+
+#include "unit-testing"
+
+// RunTest("issue109-sorting-testcases.ipf")
+
+// This example has multidata and normal tests combined, with the order
+// as theire function names, to easily detect a wrong order of test cases.
+
+// This is the first data generator function used by MDTestCaseVar
+static Function/WAVE tcDataGenVar()
+	Make/FREE data = {5, 1}
+	SetDimLabel 0, 0, first, data
+	SetDimLabel 0, 1, second, data
+	return data
+End
+
+// UTF_TD_GENERATOR tcDataGenVar
+static Function MDTestFirst([var])
+	variable var
+
+	CHECK(var == 1 || var == 5)
+End
+
+static Function TestSecond()
+	Check(1)
+End
+
+static Function/WAVE tcDataGenStr()
+	Make/FREE/T favorites = {"Dancing with the Source", "A Tear in the Veil", "The Battle for Divinity"}
+	return favorites
+End
+
+// UTF_TD_GENERATOR tcDataGenStr
+static Function MDTestThird([str])
+	string str
+
+	CHECK(strsearch(str, "the", 0, 2) >= 0)
+End
+
+static Function TestFourth()
+	Check(1)
+End
+
+static Function/WAVE tcDataGenWv()
+	Make/FREE wa = {1}
+	Make/FREE wb = {1}
+	Make/FREE/WAVE w1 = {wa, wb}
+	Make/FREE/WAVE w2 = {wa, wb}
+	Make/FREE/WAVE wr = {w1, w2}
+	return wr
+End
+
+// UTF_TD_GENERATOR tcDataGenWv
+static Function MDTestFifth([wv])
+	WAVE wv
+
+	WAVE/WAVE wr = wv
+
+	CHECK_EQUAL_WAVES(wr[0], wr[1])
+End
+
+static Function TestSixth()
+	Check(1)
+End
+
+static Function/WAVE tcDataGenDFR()
+	DFREF dfr = NewFreeDataFolder()
+	string/G dfr:data = "Damn it, Steve!"
+	Make/FREE/DF w = {dfr}
+	return w
+End
+
+// UTF_TD_GENERATOR tcDataGenDFR
+static Function MDTestSeventh([dfr])
+	DFREF dfr
+
+	SVAR/Z s = dfr:data
+	CHECK(strsearch(s, "Steve!", 0) >= 0)
+End

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -1250,7 +1250,7 @@ static Function/S CheckFunctionSignaturesTC(testCaseList, procWin)
 		// Simple Test Cases
 		FUNCREF TEST_CASE_PROTO fTC = $fullTestCase
 		if(UTF_FuncRefIsAssigned(FuncRefInfo(fTC)))
-			reducedTCList = AddListItem(testCase, reducedTCList)
+			reducedTCList = AddListItem(testCase, reducedTCList, ";", inf)
 			continue
 		endif
 		// Multi Data Test Cases
@@ -1294,7 +1294,7 @@ static Function/S CheckFunctionSignaturesTC(testCaseList, procWin)
 				UTF_PrintStatusMessage(msg)
 				continue
 			else
-				reducedTCList = AddListItem(testCase, reducedTCList)
+				reducedTCList = AddListItem(testCase, reducedTCList, ";", inf)
 			endif
 		endif
 	endfor
@@ -1411,7 +1411,7 @@ static Function/S getTestCasesMatch(procWinList, matchStr, enableRegExp, tcCount
 					sprintf errMsg, "Could not get full function name: %s", fullFuncName
 					return errMsg
 				endif
-				testCaseList = AddListItem(fullFuncName, testCaseList, ";")
+				testCaseList = AddListItem(fullFuncName, testCaseList, ";", inf)
 				tcCount += GetTestCaseCount(fullFuncName, procWin)
 			endfor
 		endfor
@@ -2481,7 +2481,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 			numItemsFFN = 1
 		endif
 
-		for(j = numItemsFFN - 1; j >= 0; j -= 1)
+		for(j = 0; j < numItemsFFN; j += 1)
 			s.j = j
 
 			if(!reentry)

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -1303,7 +1303,7 @@ static Function/S CheckFunctionSignaturesTC(testCaseList, procWin)
 End
 
 /// Returns List of Test Functions in Procedure Window procWin
-static Function/S getTestCaseList(procWin)
+static Function/S GetTestCaseList(procWin)
 	string procWin
 
 	string testCaseList = FunctionList("!*_IGNORE", ";", "KIND:18,NPARAMS:0,VALTYPE:1,WIN:" + procWin)
@@ -1315,9 +1315,45 @@ static Function/S getTestCaseList(procWin)
 	if(!UTF_Utils#IsEmpty(testCaseMDList))
 		testCaseList = testCaseList + testCaseMDList
 	endif
+	testCaseList = SortTestCaseList(procWin, testCaseList)
 
 	return CheckFunctionSignaturesTC(testCaseList, procWin)
 End
+
+/// Returns the list of testcases sorted by line number
+static Function/S SortTestCaseList(procWin, testCaseList)
+	string procWin, testCaseList
+
+	if(UTF_Utils#IsEmpty(testCaseList))
+		return ""
+	endif
+
+	Wave/T testCaseWave = ListToTextWave(testCaseList, ";")
+
+	Make/FREE/N=(ItemsInList(testCaseList)) lineNumberWave
+	lineNumberWave[] = str2num(StringByKey("PROCLINE", FunctionInfo(testCaseWave[p], procWin)))
+	
+	Sort lineNumberWave, testCaseWave
+	
+	return UTF_Utils#TextWaveToList(testCaseWave, ";")
+End
+
+#if (IgorVersion() >= 7.0)
+    // ListToTextWave is available
+#else
+/// @brief Convert a string list to a text wave
+///
+/// @param[in] list string list
+/// @param[in] sep separator string
+/// @returns wave reference to free wave
+static Function/WAVE ListToTextWave(list, sep)
+    string list, sep
+
+    Make/T/FREE/N=(ItemsInList(list, sep)) result = StringFromList(p, list, sep)
+
+    return result
+End
+#endif
 
 /// @brief get test cases matching a certain pattern
 ///

--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -51,4 +51,25 @@ threadsafe static Function IsEmpty(str)
 	return numtype(len) == 2 || len <= 0
 End
 
+
+// @brief Convert a text wave to string list
+///
+/// @param[in] txtWave 1D text wave
+/// @param[in] sep separator string
+/// @returns string with list of former text wave elements
+static Function/S TextWaveToList(txtWave, sep)
+	WAVE/T txtWave
+	string sep
+
+	string list = ""
+	variable i, numRows
+
+	numRows = DimSize(txtWave, 0)
+	for(i = 0; i < numRows; i += 1)
+		list = AddListItem(txtWave[i], list, sep, inf)
+	endfor
+
+	return list
+End
+
 ///@endcond // HIDDEN_SYMBOL


### PR DESCRIPTION
Multidata tests and normal tests now come in the right order.

.ipf file for quick tests is attached:
[issue109-sorting-testcases.zip](https://github.com/byte-physics/igor-unit-testing-framework/files/4591389/issue109-sorting-testcases.zip)

I have the feeling that in sortTestCaseList the second for-loop could be solved in a 1-liner, but have no idea how.

Edit: closes #109 