### PR TITLE
Ma issue92 error if no assertion

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -285,7 +285,7 @@ static Function DebugOutput(str, booleanValue)
 	string &str
 	variable booleanValue
 
-	sprintf str, "%s: is %s", str, SelectString(booleanValue, "false", "true")
+	sprintf str, "%s: is %s.", str, SelectString(booleanValue, "false", "true")
 	if(EnabledDebug())
 		UTF_PrintStatusMessage(str)
 	endif

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -502,7 +502,9 @@ End
 // 0 failed, 1 succeeded
 static Function/S getInfo(result)
 	variable result
-
+	
+	DFREF dfr = GetPackageFolder()
+	NVAR/SDFR=dfr assert_count
 	string caller, procedure, callStack, contents
 	string text, cleanText, line, callerTestCase
 	variable numCallers, i
@@ -532,7 +534,7 @@ static Function/S getInfo(result)
 		endif
 	endfor
 
-	if(UTF_Utils#IsNaN(callerIndex))
+	if(UTF_Utils#IsNaN(callerIndex) && assert_count != 0)
 		return "Assertion failed in unknown location"
 	endif
 
@@ -554,6 +556,10 @@ static Function/S getInfo(result)
 	text = StringFromList(str2num(line), contents, "\r")
 
 	cleanText = trimstring(text)
+
+	if(assert_count == 0)
+		return "The test case did not make any assertions!"
+	endif
 
 	sprintf text, "Assertion \"%s\" %s in line %s, procedure \"%s\"", cleanText,  SelectString(result, "failed", "succeeded"), line, procedure
 	return text
@@ -1124,11 +1130,9 @@ static Function TestCaseEnd(testCase, keepDataFolder)
 	SVAR/Z/SDFR=dfr lastFolder
 	SVAR/Z/SDFR=dfr workFolder
 	NVAR/SDFR=dfr assert_count
-
-	if(assert_count == 0)
-		sprintf msg, "The test case \"%s\" did not make any assertions!", testCase
-		UTF_PrintStatusMessage(msg)
-	endif
+	
+	sprintf msg, "Test case \"%s\" contained at least one assertion", testCase
+	ReportResults(assert_count, msg, OUTPUT_MESSAGE | INCREASE_ERROR)
 
 	if(SVAR_Exists(lastFolder) && DataFolderExists(lastFolder))
 		SetDataFolder $lastFolder

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -422,7 +422,7 @@ Function incrAssert()
 End
 
 /// Prints an informative message that the test failed
-Function printFailInfo()
+Function PrintFailInfo()
 	dfref dfr = GetPackageFolder()
 	SVAR/SDFR=dfr message
 	SVAR/SDFR=dfr status
@@ -431,7 +431,7 @@ Function printFailInfo()
 
 	sprintf message, "%s  %s", status, getInfo(0)
 
-	print message
+	UTF_PrintStatusMessage(message)
 	type = "FAIL"
 	systemErr = message
 


### PR DESCRIPTION
In a first step printFailInfo was updated to use the function UTF_PrintStatusMessage (not necessary, but it should make the output more unified) instead of a simple print.

In the second step the error handling in TestCaseEnd when the assertion counter equals 0 was changed. It does not simply print to the console without anything else, but also uses the standard ReportResults to increase the error counter and send messages via PrintFailInfo.

To get the right error message an additional return-case needed to be inserted in getInfo to get the previous message. Furthermore the case "Assertion failed in unknown location" now only triggers if the assertion counter is unequal 0. This should be no problem, because ReportResults is only called from unit-testing-assertion-wrappers.ipf, which only get called from assertions.

The documentation could not be compiled correctly, instead of doxygen input a frame appears "Warning: doxygenfunction: Cannot find function “RunTest” in doxygen xml output for project “igor-utf” from directory: xml". Please check if this is a local problem or unit testing framework documentation is broken.

Closes: #92 