### PR TITLE
Ma issue114 docu check equal waves

### DIFF
--- a/docu/sphinx/source/examples.rst
+++ b/docu/sphinx/source/examples.rst
@@ -139,7 +139,7 @@ Example4
 
 This test suite shows the use of test assertions for waves.
 
-The type of a wave can be checked with :cpp:func:`CHECK_EQUAL_WAVES` and
+The type of a wave can be checked with :cpp:func:`CHECK_WAVE` and
 binary flags for the :ref:`flags_testwave_minor` and
 :ref:`flags_testwave_major`. All flags are defined in :ref:`flags_testwave` and
 can be concatenated as shown in line 45. If the comparison is done against such a

--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -420,7 +420,7 @@ static Function EQUAL_VAR_WRAPPER(var1, var2, flags)
 End
 
 /// @class EQUAL_WAVE_DOCU
-/// Tests two waves for equality
+/// Tests two waves for equality of content (use @link WARN_WAVE@endlink, @link CHECK_WAVE@endlink or @link REQUIRE_WAVE@endlink for type)
 ///
 /// @param wv1    first wave
 /// @param wv2    second wave

--- a/procedures/unit-testing-assertions.ipf
+++ b/procedures/unit-testing-assertions.ipf
@@ -562,7 +562,7 @@ End
 #else
 
 /// @class TEXT_WAVE_EQUAL_DOCU
-/// Tests two text waves for equality
+/// Tests two text waves for equality of content (use @link WARN_WAVE@endlink, @link CHECK_WAVE@endlink or @link REQUIRE_WAVE@endlink for type)
 ///
 /// @param wv1    first text wave, can be invalid for Igor Pro 7 or later
 /// @param wv2    second text wave, can be invalid for Igor Pro 7 or later


### PR DESCRIPTION
In the first commit an error in Example4 was corrected.
After that the description for CHECK_EQUAL_WAVES was changed to state that the function only checks the content.
I tried to add the reference to CHECK_WAVES as clickable link, but it did not work easily.

Closes: #114 