### PR TITLE
MA issue102 leftover RTE

### DIFF
--- a/docu/examples/example3-plain.ipf
+++ b/docu/examples/example3-plain.ipf
@@ -16,9 +16,13 @@ Function CheckTest()
 	CHECK_EQUAL_VAR(1.0,0.0)
 End
 
-// REQUIRE_* will stop execution of the test case immediately
+// REQUIRE_* will stop execution of the test run immediately
 Function RequireTest()
 
 	REQUIRE_EQUAL_VAR(1.0,0.0)
 	print "If I'm reached math is wrong !"
+End
+
+Function AfterRequireTest()
+	print "I will never be reached. Just like all the subsequent test suites."
 End

--- a/docu/sphinx/source/examples.rst
+++ b/docu/sphinx/source/examples.rst
@@ -108,7 +108,7 @@ This test suite emphasizes the difference between the :cpp:func:`WARN`,
 The :cpp:func:`WARN_* <WARN>` variant does not increment the error count if the
 executed assertion fails. :cpp:func:`CHECK_* <CHECK>` variants increase the
 error count. :cpp:func:`REQUIRE_* <REQUIRE>` variants also increment the error
-count but will stop the execution of the test case immediately if the assertion
+count but will stop the execution of the test run immediately if the assertion
 fails.
 
 Even if a test has failed, the test end hook is still executed. See

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -921,6 +921,7 @@ static Function EvaluateRTE(err, errmessage, abortCode, funcName, funcType, proc
 
 	UTF_PrintStatusMessage(message)
 	systemErr = message
+	incrError()
 
 	CheckAbortCondition(abortCode)
 	if(TAP_IsOutputEnabled())
@@ -1682,7 +1683,6 @@ static Function ExecuteHooks(hookType, hooks, juProps, name, procWin, [param])
 		EvaluateRTE(err, errorMessage, V_AbortCode, name, USER_HOOK_TYPE, procWin)
 
 		setAbortFlag()
-		incrError()
 	endtry
 
 	switch(hookType)
@@ -2573,13 +2573,9 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 						ClearRTError()
 						CallTestCase(s, reentry)
 					catch
-						// only complain here if the error counter if the abort happened not in our code
-						if(!shouldDoAbort())
-							message = GetRTErrMessage()
-							s.err = GetRTError(1)
-							EvaluateRTE(s.err, message, V_AbortCode, s.fullFuncName, TEST_CASE_TYPE, s.procWin)
-							incrError()
-						endif
+						message = GetRTErrMessage()
+						s.err = GetRTError(1)
+						EvaluateRTE(s.err, message, V_AbortCode, s.fullFuncName, TEST_CASE_TYPE, s.procWin)
 
 						if(shouldDoAbort())
 							// abort condition is on hold while in catch/endtry, so all cleanup must happen here


### PR DESCRIPTION
A RTE is now detected even if the abort flag is set. incrError was moved inside EvaluateRTE, because it belongs together.

An Error in the explanation of example3 was found, and example3 was expanded to show that an abort stops the whole test run.

Edit: Closes #102 