### PR TITLE
MA issue10 debugMode option

### DIFF
--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -21,7 +21,7 @@ static Function CDF_EMPTY_WRAPPER(flags)
 	endif
 
 	result = UTF_Checks#IsDataFolderEmpty(":")
-	ReportResults(result, "Assumption that the current data folder is empty is", flags)
+	EvaluateResults(result, "Assumption that the current data folder is empty is", flags)
 End
 
 /// @class TRUE_DOCU
@@ -41,7 +41,7 @@ static Function TRUE_WRAPPER(var, flags)
 	endif
 
 	result = UTF_Checks#IsTrue(var)
-	ReportResults(result, num2istr(var), flags)
+	EvaluateResults(result, num2istr(var), flags)
 End
 
 /// @class NULL_STR_DOCU
@@ -62,7 +62,7 @@ static Function NULL_STR_WRAPPER(str, flags)
 	endif
 
 	result = UTF_Checks#IsNullString(str)
-	ReportResults(result, "Assumption that str is null is", flags)
+	EvaluateResults(result, "Assumption that str is null is", flags)
 End
 
 /// @class EMPTY_STR_DOCU
@@ -83,7 +83,7 @@ static Function EMPTY_STR_WRAPPER(str, flags)
 	endif
 
 	result = UTF_Checks#IsEmptyString(str)
-	ReportResults(result, "Assumption that the string is empty is", flags)
+	EvaluateResults(result, "Assumption that the string is empty is", flags)
 End
 
 /// @class NON_NULL_STR_DOCU
@@ -104,7 +104,7 @@ static Function NON_NULL_STR_WRAPPER(str, flags)
 	endif
 
 	result = !UTF_Checks#IsNullString(str)
-	ReportResults(result, "Assumption of the string being non null is", flags)
+	EvaluateResults(result, "Assumption of the string being non null is", flags)
 End
 
 /// @class NON_EMPTY_STR_DOCU
@@ -125,7 +125,7 @@ static Function NON_EMPTY_STR_WRAPPER(str, flags)
 	endif
 
 	result = !UTF_Checks#IsEmptyString(str)
-	ReportResults(result, "Assumption that the string is non empty is", flags)
+	EvaluateResults(result, "Assumption that the string is non empty is", flags)
 End
 
 /// @class PROPER_STR_DOCU
@@ -147,7 +147,7 @@ static Function PROPER_STR_WRAPPER(str, flags)
 	endif
 
 	result = UTF_Checks#IsProperString(str)
-	ReportResults(result, "Assumption that the string is a proper string is", flags)
+	EvaluateResults(result, "Assumption that the string is a proper string is", flags)
 End
 
 /// @class NEQ_VAR_DOCU
@@ -170,7 +170,7 @@ static Function NEQ_VAR_WRAPPER(var1, var2, flags)
 
 	result = !UTF_Checks#AreVariablesEqual(var1, var2)
 	sprintf str, "%g != %g", var1, var2
-	ReportResults(result, str, flags)
+	EvaluateResults(result, str, flags)
 End
 
 /// @class NEQ_STR_DOCU
@@ -200,7 +200,7 @@ static Function NEQ_STR_WRAPPER(str1, str2, flags, [case_sensitive])
 	result = !UTF_Checks#AreStringsEqual(str1, str2, case_sensitive)
 	sprintf str, "\"%s\" != \"%s\" %s case", SelectString(UTF_Checks#IsNullString(str1), str1, "(null)"), SelectString(UTF_Checks#IsNullString(str2), str2, "(null)"), SelectString(case_sensitive, "not respecting", "respecting")
 
-	ReportResults(result, str, flags)
+	EvaluateResults(result, str, flags)
 End
 
 /// @class CLOSE_VAR_DOCU
@@ -241,7 +241,7 @@ static Function CLOSE_VAR_WRAPPER(var1, var2, flags, [tol, strong])
 
 	result = UTF_Checks#AreVariablesClose(var1, var2, tol, strong)
 	sprintf str, "%g ~ %g with %s check and tol %g", var1, var2, SelectString(strong, "weak", "strong"), tol
-	ReportResults(result, str, flags)
+	EvaluateResults(result, str, flags)
 End
 
 /// @class CLOSE_CMPLX_DOCU
@@ -273,7 +273,7 @@ static Function CLOSE_CMPLX_WRAPPER(var1, var2, flags, [tol, strong])
 
 	result = UTF_Checks#AreVariablesClose(real(var1), real(var2), tol, strong) && UTF_Checks#AreVariablesClose(imag(var1), imag(var2), tol, strong)
 	sprintf str, "(%g, %g) ~ (%g, %g) with %s check and tol %g", real(var1), imag(var1), real(var2), imag(var2), SelectString(strong, "weak", "strong"), tol
-	ReportResults(result, str, flags)
+	EvaluateResults(result, str, flags)
 End
 
 /// @class SMALL_VAR_DOCU
@@ -301,7 +301,7 @@ static Function SMALL_VAR_WRAPPER(var, flags, [tol])
 
 	result = UTF_Checks#IsVariableSmall(var, tol)
 	sprintf str, "%g ~ 0 with tol %g", var, tol
-	ReportResults(result, str, flags)
+	EvaluateResults(result, str, flags)
 End
 
 /// @class SMALL_CMPLX_DOCU
@@ -328,7 +328,7 @@ static Function SMALL_CMPLX_WRAPPER(var, flags, [tol])
 
 	result = UTF_Checks#IsVariableSmall(cabs(var), tol)
 	sprintf str, "(%g, %g) ~ 0 with tol %g", real(var), imag(var), tol
-	ReportResults(result, str, flags)
+	EvaluateResults(result, str, flags)
 End
 
 /// @class EQUAL_STR_DOCU
@@ -357,7 +357,7 @@ static Function EQUAL_STR_WRAPPER(str1, str2, flags, [case_sensitive])
 
 	result = UTF_Checks#AreStringsEqual(str1, str2, case_sensitive)
 	sprintf str, "\"%s\" == \"%s\" %s case", SelectString(UTF_Checks#IsNullString(str1), str1, "(null)"), SelectString(UTF_Checks#IsNullString(str2), str2, "(null)"), SelectString(case_sensitive, "not respecting", "respecting")
-	ReportResults(result, str, flags)
+	EvaluateResults(result, str, flags)
 End
 
 /// @class WAVE_DOCU
@@ -383,12 +383,12 @@ static Function TEST_WAVE_WRAPPER(wv, majorType, flags, [minorType])
 
 	result = UTF_Checks#HasWaveMajorType(wv, majorType)
 	sprintf str, "Assumption that the wave's main type is %d", majorType
-	ReportResults(result, str, flags)
+	EvaluateResults(result, str, flags)
 
 	if(!ParamIsDefault(minorType))
 		result = UTF_Checks#HasWaveMinorType(wv, minorType)
 		sprintf str, "Assumption that the wave's sub type is %d", minorType
-		ReportResults(result, str, flags)
+		EvaluateResults(result, str, flags)
 	endif
 End
 
@@ -416,7 +416,7 @@ static Function EQUAL_VAR_WRAPPER(var1, var2, flags)
 
 	result = UTF_Checks#AreVariablesEqual(var1, var2)
 	sprintf str, "%g == %g", var1, var2
-	ReportResults(result, str, flags)
+	EvaluateResults(result, str, flags)
 End
 
 /// @class EQUAL_WAVE_DOCU
@@ -441,21 +441,21 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 	endif
 
 	result = WaveExists(wv1)
-	ReportResults(result, "Assumption that the first wave (wv1) exists", flags)
+	EvaluateResults(result, "Assumption that the first wave (wv1) exists", flags)
 
 	if(!result)
 		return NaN
 	endif
 
 	result = WaveExists(wv2)
-	ReportResults(result, "Assumption that the second wave (wv2) exists", flags)
+	EvaluateResults(result, "Assumption that the second wave (wv2) exists", flags)
 
 	if(!result)
 		return NaN
 	endif
 
 	result = !WaveRefsEqual(wv1, wv2)
-	ReportResults(result, "Assumption that both waves are distinct", flags)
+	EvaluateResults(result, "Assumption that both waves are distinct", flags)
 
 	if(!result)
 		return NaN
@@ -481,6 +481,6 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 			str += "; detailed: " + detailedMsg
 		endif
 
-		ReportResults(result, str, flags)
+		EvaluateResults(result, str, flags)
 	endfor
 End

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -313,10 +313,25 @@ Function SetTestStatusAndDebug(str, booleanValue)
 	SetTestStatus(str)
 End
 
-/// Disable the Igor Pro Debugger and return its state prior to deactivation
-static Function DisableIgorDebugger()
+Function EvaluateResults(result, str, flags)
+	variable result, flags
+	string str
+	
+	DebugFailedAssertion(result)
+	ReportResults(result, str, flags)
+End
 
-	variable debuggerState
+/// Opens the Debugger if the assertion failed and the debugMode option is set
+static Function DebugFailedAssertion(result)
+	variable result
+
+	DFREF dfr = GetPackageFolder()
+	NVAR/SDFR=dfr igor_debug_assertion
+
+	if(igor_debug_assertion && !result)
+		Debugger
+	endif
+End
 
 /// Set the Igor Debugger, returns the previous state
 /// @param state		3 bits to set
@@ -506,7 +521,7 @@ End
 /// @param result Return value of a check function from `unit-testing-assertion-checks.ipf`
 /// @param str    Message string
 /// @param flags  Wrapper function `flags` argument
-Function ReportResults(result, str, flags)
+static Function ReportResults(result, str, flags)
 	variable result, flags
 	string str
 

--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -51,6 +51,12 @@ threadsafe static Function IsEmpty(str)
 	return numtype(len) == 2 || len <= 0
 End
 
+/// @brief Returns one if var is a nonfinite integer, zero otherwise
+threadsafe static Function IsInteger(var)
+	variable var
+
+	return trunc(var) == var && numtype(var) == 0
+End
 
 // @brief Convert a text wave to string list
 ///


### PR DESCRIPTION
The debugMode option was added which has 3 bits to set:
0x01: debug on RT error
0x02: debug on NVAR SVAR WAVE reference error
0x04: debug on failed assertion

Closes #10 

Open Questions:
 - At the beginning of RunTest(), debugMode is tested to be within 0 and 7. Does it need to be tested for integer values, e.g. by trunk(debugMode) == debugMode ?
- The constants DEBUG_ENABLE and DEBUG_ALLOW have the same value, but are used in different contexts. Is it OK to have two constants?
 - EnableIgorDebugger() gives a 4 bit variable to SetIgorDebugger(), which only uses the 3 least significant bits. Is this a possible bug in the future, so it should only pass 3 bits?