### PR TITLE
AreWavesEqual creates better message for wave data check

### DIFF
--- a/internal_dev/EqualWaves_Examples.ipf
+++ b/internal_dev/EqualWaves_Examples.ipf
@@ -30,6 +30,13 @@ Function EqualWavesType1()
 	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
 End
 
+Function EqualWavesType1_1()
+
+	Make/FREE/N=0/D wv1
+	Make/FREE/N=1/I wv2
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
 Function EqualWavesType2()
 
 	Make/FREE/N=1/D wv1
@@ -61,6 +68,22 @@ Function EqualWaves3()
 	Make/FREE wTest1, wTest2
 	Make/FREE/WAVE wv1 = {wTest1, wTest2}
 	Make/FREE/WAVE wv2 = {wTest2, wTest1}
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
+Function EqualWaves3_1()
+
+	Make/FREE wTest1, wTest2
+	Make/FREE/WAVE wv1 = {wTest1, wTest2}
+	Make/FREE wv2 = {0, 0}
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
+Function EqualWaves3_2()
+
+	Make/FREE wTest1, wTest2
+	Make/FREE/WAVE wv1 = {wTest1, wTest2}
+	Make/FREE/DF wv2 = {NewFreeDataFolder(), NewFreeDataFolder()}
 	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
 End
 

--- a/internal_dev/EqualWaves_Examples.ipf
+++ b/internal_dev/EqualWaves_Examples.ipf
@@ -1,0 +1,184 @@
+#pragma rtGlobals=3
+#pragma TextEncoding = "UTF-8"
+#pragma rtFunctionErrors=1
+
+#include "unit-testing"
+
+// All tests here should fail and give an detailed message
+// from CHECK_EQUAL_WAVES in WAVE_DATA mode
+
+Function EqualWavesTol()
+
+	CHECK_EQUAL_WAVES({1}, {1}, mode=WAVE_DATA, tol=NaN)
+End
+
+Function EqualWavesNull()
+
+	WAVE/Z wv1 = $""
+	CHECK_EQUAL_WAVES(wv1, {1}, mode=WAVE_DATA)
+End
+
+Function EqualWavesSize()
+
+	CHECK_EQUAL_WAVES({1}, {2, 3}, mode=WAVE_DATA)
+End
+
+Function EqualWavesType1()
+
+	Make/FREE/N=0/D wv1
+	Make/FREE/N=0/I wv2
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
+Function EqualWavesType2()
+
+	Make/FREE/N=1/D wv1
+	Make/FREE/N=1/T wv2
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
+Function EqualWavesType3()
+
+	Make/FREE/N=1/D wv1
+	Make/FREE/N=1/D/C wv2
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
+Function EqualWaves1()
+
+	CHECK_EQUAL_WAVES({1}, {2}, mode=WAVE_DATA)
+End
+
+Function EqualWaves2()
+
+	Make/FREE/T wv1 = {"1"}
+	Make/FREE/T wv2 = {"2"}
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
+Function EqualWaves3()
+
+	Make/FREE wTest1, wTest2
+	Make/FREE/WAVE wv1 = {wTest1, wTest2}
+	Make/FREE/WAVE wv2 = {wTest2, wTest1}
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
+Function EqualWaves4()
+
+	Make/FREE/DF wv1 = {NewFreeDataFolder()}
+	Make/FREE/DF wv2 = {NewFreeDataFolder()}
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
+Function EqualWaves5()
+
+	Make/FREE/C/D wv1 = {cmplx(Inf, NaN)}
+	Make/FREE/C/D wv2 = {cmplx(NaN, Inf)}
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
+// expect 8 errors in table from 20 to 27, [1][0][2][0] to [2][2][2][0]
+// this also proves the correct indexing order in checking
+Function EqualWaves6()
+
+	Make/FREE/N=(3, 3, 3) wv1
+	Make/FREE/N=(3, 3, 3) wv2
+	wv1 = p + 3 * q
+	wv1 = wv2 + 1
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA, tol = 20)
+End
+
+Function SetDimLabelImpl(w, row, col, layer)
+	WAVE w
+	variable row, col, layer
+
+	SetDimLabel 0, row, $("ROW" + num2str(row)), w
+	SetDimLabel 1, col, $("COL" + num2str(col)), w
+	SetDimLabel 2, layer, $("LAYER" + num2str(layer)), w
+End
+
+Function EqualWaves7()
+
+	Make/FREE/N=(3, 3, 3) wv1
+	Make/FREE/N=(3, 3, 3) wv2
+	wv2 = SetDimLabelImpl(wv2, p, q, r)
+	wv1 = p + 3 * q
+	wv2 = wv1 + 1
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA, tol = 20)
+End
+
+Function EqualWaves8()
+
+	NewDataFolder there
+	DFREF dfr1 = there
+	NewDataFolder here
+	DFREF dfr2 = here
+	Make/T dfr1:there = {"must be here"}
+	Make/T dfr2:here = {"should be there"}
+	WAVE wv1 = dfr1:there
+	WAVE wv2 = dfr2:here
+	CHECK_EQUAL_WAVES(wv1, wv2, mode=WAVE_DATA)
+End
+
+Function EqualWavesTextWithNulls()
+
+	string str1, str2
+
+	str1 = "abcd"
+	str2 = PadString(str1, strlen(str1) + 1, 0x0)
+
+	CHECK_EQUAL_TEXTWAVES({str1}, {str2}, mode=WAVE_DATA)
+End
+
+#if IgorVersion() >= 7.00
+Function EqualWavesTextWithUTF8()
+
+	string str1, str2
+
+	str1 = "AΔ♣∑B" + U+2022 + U+061C
+	str2 = PadString(str1, strlen(str1) + 1, 0x0)
+
+	CHECK_EQUAL_TEXTWAVES({str1}, {str2}, mode=WAVE_DATA)
+End
+
+Function EqualWavesUINT64()
+
+	Make/FREE/L/U/N=1 wInt1, wInt2
+	wInt1[0] = 0xFFFFFFFFFFFFFFFF
+	wInt2[0] = wInt1[0] - 1
+
+	CHECK_EQUAL_WAVES(wInt1, wInt2, mode=WAVE_DATA, tol = 0.99)
+End
+
+Function EqualWavesINT64()
+
+	Make/FREE/L/N=1 wInt1, wInt2
+	wInt1[0] = 0x7FFFFFFFFFFFFFFF
+	wInt2[0] = wInt1[0] - 1
+
+	CHECK_EQUAL_WAVES(wInt1, wInt2, mode=WAVE_DATA, tol = 0.99)
+End
+
+Function EqualWavesComplexINT64()
+
+	Make/FREE/C/L/N=1 wInt1, wInt2
+	INT64 vi = 0x7FFFFFFFFFFFFFFF
+	wInt1[0] += vi
+	wInt2[0] += vi
+	wInt2[0] -= 1
+
+	CHECK_EQUAL_WAVES(wInt1, wInt2, mode=WAVE_DATA, tol = 0.99)
+End
+
+Function EqualWavesComplexUINT64()
+
+	Make/FREE/C/L/U/N=1 wInt1, wInt2
+	INT64 vi = 0xFFFFFFFFFFFFFFFF
+	wInt1[0] += vi
+	wInt2[0] += vi
+	wInt2[0] -= 1
+
+	CHECK_EQUAL_WAVES(wInt1, wInt2, mode=WAVE_DATA, tol = 0.99)
+End
+#endif

--- a/procedures/unit-testing-assertion-checks.ipf
+++ b/procedures/unit-testing-assertion-checks.ipf
@@ -198,42 +198,51 @@ static Function AreWavesEqual(wv1, wv2, mode, tol, detailedMsg)
 	variable mode, tol
 	string &detailedMsg
 
+	string waveDataMsg = ""
+	string dimLabelMsg = ""
 	variable result, err
 
 	result = EqualWaves(wv1, wv2, mode, tol) == 1
 
-	detailedMsg = ""
-
 	if(!result)
 		switch(mode)
-			 case WAVE_DATA:
-			 case WAVE_DATA_TYPE:
-			 case WAVE_SCALING:
-			 case DATA_UNITS:
-			 case DIMENSION_UNITS:
-			 case WAVE_NOTE:
-			 case WAVE_LOCK_STATE:
-			 case DATA_FULL_SCALE:
-			 case DIMENSION_SIZES:
-				 // FIXME add detailed msg generation functions
-				 break
-			 case DIMENSION_LABELS:
+			case WAVE_DATA:
+				waveDataMsg = UTF_Utils#DetermineWaveDataDifference(wv1, wv2, tol)
+			case WAVE_DATA_TYPE:
+			case WAVE_SCALING:
+			case DATA_UNITS:
+			case DIMENSION_UNITS:
+			case WAVE_NOTE:
+			case WAVE_LOCK_STATE:
+			case DATA_FULL_SCALE:
+			case DIMENSION_SIZES:
+				// FIXME add detailed msg generation functions
+				break
+			case DIMENSION_LABELS:
 				// work around buggy EqualWaves versions which detect some
 				// waves as differing but they are not in reality
 #if IgorVersion() >= 9.0
-				GenerateDimLabelDifference(wv1, wv2, detailedMsg)
+				GenerateDimLabelDifference(wv1, wv2, dimLabelMsg)
 #elif IgorVersion() >= 8.0
 #if NumberByKey("BUILD", IgorInfo(0)) >= 33425
-				GenerateDimLabelDifference(wv1, wv2, detailedMsg)
+				GenerateDimLabelDifference(wv1, wv2, dimLabelMsg)
 #else // old IP8
-				result = GenerateDimLabelDifference(wv1, wv2, detailedMsg)
+				result = GenerateDimLabelDifference(wv1, wv2, dimLabelMsg)
 #endif
 #else // IP7 and older
-				result = GenerateDimLabelDifference(wv1, wv2, detailedMsg)
+				result = GenerateDimLabelDifference(wv1, wv2, dimLabelMsg)
 #endif
 				break
 		endswitch
+
+		detailedMsg = waveDataMsg
+		if(!UTF_Utils#IsEmpty(dimLabelMsg))
+			detailedMsg += "\r" + dimLabelMsg
+		endif
+	else
+		detailedMsg = ""
 	endif
+
 
 	return result
 End

--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -688,6 +688,18 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 		return NaN
 	endif
 
+	if(WaveType(wv1, 1) != WaveType(wv2, 1))
+		EvaluateResults(0, "Compatible basic wave type for EQUAL_WAVE check.", flags)
+		return NaN
+	endif
+
+	if(!numpnts(wv1) || !numpnts(wv2))
+		if(WaveType(wv1) != WaveType(wv2))
+			EvaluateResults(0, "Compatible wave type of zero sized wave for EQUAL_WAVE check.", flags)
+			return NaN
+		endif
+	endif
+
 	for(i = 0; i < DimSize(modes, 0); i += 1)
 		mode = modes[i]
 		result = UTF_Checks#AreWavesEqual(wv1, wv2, mode, tol, detailedMsg)

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -32,20 +32,20 @@ static Constant TEST_CASE_END_CONST    = 0x20
 /// @name Constants for WaveTypes
 /// @anchor WaveTypes
 /// @{
-static Constant WAVETYPE0_CMPL = 0x01
-static Constant WAVETYPE0_FP32 = 0x02
-static Constant WAVETYPE0_FP64 = 0x04
-static Constant WAVETYPE0_INT8 = 0x08
-static Constant WAVETYPE0_INT16 = 0x10
-static Constant WAVETYPE0_INT32 = 0x20
-static Constant WAVETYPE0_INT64 = 0x80
-static Constant WAVETYPE0_USGN = 0x40
+Constant IUTF_WAVETYPE0_CMPL = 0x01
+Constant IUTF_WAVETYPE0_FP32 = 0x02
+Constant IUTF_WAVETYPE0_FP64 = 0x04
+Constant IUTF_WAVETYPE0_INT8 = 0x08
+Constant IUTF_WAVETYPE0_INT16 = 0x10
+Constant IUTF_WAVETYPE0_INT32 = 0x20
+Constant IUTF_WAVETYPE0_INT64 = 0x80
+Constant IUTF_WAVETYPE0_USGN = 0x40
 
-static Constant WAVETYPE1_NULL = 0x00
-static Constant WAVETYPE1_NUM = 0x01
-static Constant WAVETYPE1_TEXT = 0x02
-static Constant WAVETYPE1_DFR = 0x03
-static Constant WAVETYPE1_WREF = 0x04
+Constant IUTF_WAVETYPE1_NULL = 0x00
+Constant IUTF_WAVETYPE1_NUM = 0x01
+Constant IUTF_WAVETYPE1_TEXT = 0x02
+Constant IUTF_WAVETYPE1_DFR = 0x03
+Constant IUTF_WAVETYPE1_WREF = 0x04
 /// @}
 
 /// @name Constants for Debugger mode
@@ -1418,29 +1418,29 @@ static Function GetFunctionSignatureTCMD(testCase, wType0, wType1, wrefSubType)
 	FUNCREF TEST_CASE_PROTO_MD_CMPL fTCMDCMPL = $testCase
 	FUNCREF TEST_CASE_PROTO_MD_INT fTCMDINT = $testCase
 	if(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMDVAR)))
-		wType0 = 0xff %^ WAVETYPE0_CMPL %^ WAVETYPE0_INT64
-		wType1 = WAVETYPE1_NUM
+		wType0 = 0xff %^ IUTF_WAVETYPE0_CMPL %^ IUTF_WAVETYPE0_INT64
+		wType1 = IUTF_WAVETYPE1_NUM
 	elseif(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMDSTR)))
-		wType1 = WAVETYPE1_TEXT
+		wType1 = IUTF_WAVETYPE1_TEXT
 	elseif(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMDDFR)))
-		wType1 = WAVETYPE1_DFR
+		wType1 = IUTF_WAVETYPE1_DFR
 	elseif(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMDWV)))
-		wType1 = WAVETYPE1_WREF
+		wType1 = IUTF_WAVETYPE1_WREF
 	elseif(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMDWVTEXT)))
-		wType1 = WAVETYPE1_WREF
-		wrefSubType = WAVETYPE1_TEXT
+		wType1 = IUTF_WAVETYPE1_WREF
+		wrefSubType = IUTF_WAVETYPE1_TEXT
 	elseif(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMDWVDFREF)))
-		wType1 = WAVETYPE1_WREF
-		wrefSubType = WAVETYPE1_DFR
+		wType1 = IUTF_WAVETYPE1_WREF
+		wrefSubType = IUTF_WAVETYPE1_DFR
 	elseif(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMDWVWAVEREF)))
-		wType1 = WAVETYPE1_WREF
-		wrefSubType = WAVETYPE1_WREF
+		wType1 = IUTF_WAVETYPE1_WREF
+		wrefSubType = IUTF_WAVETYPE1_WREF
 	elseif(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMDCMPL)))
-		wType0 = WAVETYPE0_CMPL
-		wType1 = WAVETYPE1_NUM
+		wType0 = IUTF_WAVETYPE0_CMPL
+		wType1 = IUTF_WAVETYPE1_NUM
 	elseif(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMDINT)))
-		wType0 = WAVETYPE0_INT64
-		wType1 = WAVETYPE1_NUM
+		wType0 = IUTF_WAVETYPE0_INT64
+		wType1 = IUTF_WAVETYPE1_NUM
 	else
 		return 0
 	endif
@@ -1506,7 +1506,7 @@ static Function/S CheckFunctionSignaturesTC(testCaseList, procWin)
 				sprintf msg, "Data Generator function %s returns not a 1D wave. It is referenced by test case %s.", dgen, fullTestCase
 				UTF_PrintStatusMessage(msg)
 				Abort msg
-			elseif(!((wType1 == WAVETYPE1_NUM && WaveType(wGenerator, 1) == wType1 && WaveType(wGenerator) & wType0) || (wType1 != WAVETYPE1_NUM && WaveType(wGenerator, 1) == wType1)))
+			elseif(!((wType1 == IUTF_WAVETYPE1_NUM && WaveType(wGenerator, 1) == wType1 && WaveType(wGenerator) & wType0) || (wType1 != IUTF_WAVETYPE1_NUM && WaveType(wGenerator, 1) == wType1)))
 				sprintf msg, "Data Generator %s functions returned wave format does not fit to expected test case parameter. It is referenced by test case %s.", dgen, fullTestCase
 				UTF_PrintStatusMessage(msg)
 				Abort msg
@@ -1514,7 +1514,7 @@ static Function/S CheckFunctionSignaturesTC(testCaseList, procWin)
 				sprintf msg, "Data Generator function %s returns a wave with zero points. It is referenced by test case %s.", dgen, fullTestCase
 				UTF_PrintStatusMessage(msg)
 				continue
-			elseif(!UTF_Utils#IsNaN(wRefSubType) && wType1 == WAVETYPE1_WREF && !UTF_Utils#HasConstantWaveTypes(wGenerator, wRefSubType))
+			elseif(!UTF_Utils#IsNaN(wRefSubType) && wType1 == IUTF_WAVETYPE1_WREF && !UTF_Utils#HasConstantWaveTypes(wGenerator, wRefSubType))
 				sprintf msg, "Test case %s expects specific wave type1 %u from the Data Generator %s. The wave type from the data generator does not fit to expected wave type.", fullTestCase, wRefSubType, dgen
 				UTF_PrintStatusMessage(msg)
 				Abort msg
@@ -2311,8 +2311,8 @@ static Function CallTestCase(s, reentry)
 		WAVE wGenerator = DataGenFunc()
 		wType0 = WaveType(wGenerator)
 		wType1 = WaveType(wGenerator, 1)
-		if(wType1 == WAVETYPE1_NUM)
-			if(wType0 & WAVETYPE0_CMPL)
+		if(wType1 == IUTF_WAVETYPE1_NUM)
+			if(wType0 & IUTF_WAVETYPE0_CMPL)
 
 				FUNCREF TEST_CASE_PROTO_MD_CMPL fTCMD_CMPL = $func
 				if(reentry && !UTF_FuncRefIsAssigned(FuncRefInfo(fTCMD_CMPL)))
@@ -2323,7 +2323,7 @@ static Function CallTestCase(s, reentry)
 				endif
 				fTCMD_CMPL(cmpl=wGenerator[s.dgenIndex]); AbortOnRTE
 
-			elseif(wType0 & WAVETYPE0_INT64)
+			elseif(wType0 & IUTF_WAVETYPE0_INT64)
 
 				FUNCREF TEST_CASE_PROTO_MD_INT fTCMD_INT = $func
 				if(reentry && !UTF_FuncRefIsAssigned(FuncRefInfo(fTCMD_INT)))
@@ -2346,7 +2346,7 @@ static Function CallTestCase(s, reentry)
 				fTCMD_VAR(var=wGenerator[s.dgenIndex]); AbortOnRTE
 
 			endif
-		elseif(wType1 == WAVETYPE1_TEXT)
+		elseif(wType1 == IUTF_WAVETYPE1_TEXT)
 
 			WAVE/T wGeneratorStr = DataGenFunc()
 			FUNCREF TEST_CASE_PROTO_MD_STR fTCMD_STR = $func
@@ -2358,7 +2358,7 @@ static Function CallTestCase(s, reentry)
 			endif
 			fTCMD_STR(str=wGeneratorStr[s.dgenIndex]); AbortOnRTE
 
-		elseif(wType1 == WAVETYPE1_DFR)
+		elseif(wType1 == IUTF_WAVETYPE1_DFR)
 
 			WAVE/DF wGeneratorDF = DataGenFunc()
 			FUNCREF TEST_CASE_PROTO_MD_DFR fTCMD_DFR = $func
@@ -2370,7 +2370,7 @@ static Function CallTestCase(s, reentry)
 			endif
 			fTCMD_DFR(dfr=wGeneratorDF[s.dgenIndex]); AbortOnRTE
 
-		elseif(wType1 == WAVETYPE1_WREF)
+		elseif(wType1 == IUTF_WAVETYPE1_WREF)
 
 			WAVE/WAVE wGeneratorWV = DataGenFunc()
 			FUNCREF TEST_CASE_PROTO_MD_WV fTCMD_WV = $func
@@ -2378,21 +2378,21 @@ static Function CallTestCase(s, reentry)
 				fTCMD_WV(wv=wGeneratorWV[s.dgenIndex]); AbortOnRTE
 			else
 				wRefSubType = WaveType(wGeneratorWV[s.dgenIndex], 1)
-				if(wRefSubType == WAVETYPE1_TEXT)
+				if(wRefSubType == IUTF_WAVETYPE1_TEXT)
 					FUNCREF TEST_CASE_PROTO_MD_WVTEXT fTCMD_WVTEXT = $func
 					if(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMD_WVTEXT)))
 						fTCMD_WVTEXT(wv=wGeneratorWV[s.dgenIndex]); AbortOnRTE
 					else
 						err = 1
 					endif
-				elseif(wRefSubType == WAVETYPE1_DFR)
+				elseif(wRefSubType == IUTF_WAVETYPE1_DFR)
 					FUNCREF TEST_CASE_PROTO_MD_WVDFREF fTCMD_WVDFREF = $func
 					if(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMD_WVDFREF)))
 						fTCMD_WVDFREF(wv=wGeneratorWV[s.dgenIndex]); AbortOnRTE
 					else
 						err = 1
 					endif
-				elseif(wRefSubType == WAVETYPE1_WREF)
+				elseif(wRefSubType == IUTF_WAVETYPE1_WREF)
 					FUNCREF TEST_CASE_PROTO_MD_WVWAVEREF fTCMD_WVWAVEREF = $func
 					if(UTF_FuncRefIsAssigned(FuncRefInfo(fTCMD_WVWAVEREF)))
 						fTCMD_WVWAVEREF(wv=wGeneratorWV[s.dgenIndex]); AbortOnRTE

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -71,6 +71,7 @@ static StrConstant NO_SOURCE_PROCEDURE = "No source procedure"
 static StrConstant BACKGROUNDMONTASK   = "UTFBackgroundMonitor"
 static StrConstant BACKGROUNDMONFUNC   = "UTFBackgroundMonitor"
 static StrConstant BACKGROUNDINFOSTR   = ":UNUSED_FOR_REENTRY:"
+static Constant IP8_PRINTF_STR_MAX_LENGTH = 2400
 
 /// @brief Helper function for try/catch with AbortOnRTE
 ///
@@ -296,7 +297,7 @@ static Function DebugOutput(str, booleanValue)
 	string &str
 	variable booleanValue
 
-	sprintf str, "%s: is %s.", str, SelectString(booleanValue, "false", "true")
+	str = str + ": is " + SelectString(booleanValue, "false", "true") + "."
 	if(EnabledDebug())
 		UTF_PrintStatusMessage(str)
 	endif
@@ -496,7 +497,7 @@ Function PrintFailInfo([prefix])
 	prefix = SelectString(ParamIsDefault(prefix), prefix, "")
 
 	str = getInfo(0)
-	sprintf message, "%s%s  %s", prefix, status, UTF_Utils#PrepareStringForOut(str)
+	message = prefix + status + " " + str
 
 	UTF_PrintStatusMessage(message)
 	type = "FAIL"
@@ -1366,9 +1367,19 @@ static Function UTF_PrintStatusMessage(msg)
 		return NaN
 	endif
 
+#if (IgorVersion() >= 9.0)
 	printf "%s\r", msg
+#elif  (IgorVersion() >= 8.0)
+	print/LEN=2500 msg
+#elif  (IgorVersion() >= 7.0)
+	print/LEN=1000 msg
+#elif  (IgorVersion() >= 6.0)
+	print/LEN=400 msg
+#endif
 
 #if (IgorVersion() >= 8.0)
+	fprintf -1, "%s\r\n", UTF_Utils#PrepareStringForOut(msg, maxLen = IP8_PRINTF_STR_MAX_LENGTH - 2)
+#elif	(IgorVersion() >= 9.0)
 	fprintf -1, "%s\r\n", msg
 #endif
 End

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -46,6 +46,10 @@ Constant IUTF_WAVETYPE1_NUM = 0x01
 Constant IUTF_WAVETYPE1_TEXT = 0x02
 Constant IUTF_WAVETYPE1_DFR = 0x03
 Constant IUTF_WAVETYPE1_WREF = 0x04
+
+Constant IUTF_WAVETYPE2_NULL = 0x00
+Constant IUTF_WAVETYPE2_GLOBAL = 0x01
+Constant IUTF_WAVETYPE2_FREE = 0x02
 /// @}
 
 /// @name Constants for Debugger mode

--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -6,6 +6,8 @@
 
 // Licensed under 3-Clause BSD, see License.txt
 
+static Constant UTF_MAXDIFFCOUNT = 10
+
 ///@cond HIDDEN_SYMBOL
 
 // Choosen so that we don't hit the IP6 limit of 1000 chars
@@ -232,3 +234,667 @@ static Function HasConstantWaveTypes(wv, subType)
 	FindValue/V=(0) matches
 	return V_Value == -1
 End
+
+static Function/S GetTypeStrFromWaveType(wv)
+	WAVE wv
+
+	string str = ""
+	variable type1, type0
+
+	type0 = WaveType(wv)
+	if(type0)
+		if(type0 & IUTF_WAVETYPE0_CMPL)
+			str += "complex "
+		endif
+		if(type0 & IUTF_WAVETYPE0_USGN)
+			str += "unsigned "
+		endif
+		if(type0 & IUTF_WAVETYPE0_FP32)
+			str += "32-bit float"
+		endif
+		if(type0 & IUTF_WAVETYPE0_FP64)
+			str += "64-bit float"
+		endif
+		if(type0 & IUTF_WAVETYPE0_INT8)
+			str += "8-bit integer"
+		endif
+		if(type0 & IUTF_WAVETYPE0_INT16)
+			str += "16-bit integer"
+		endif
+		if(type0 & IUTF_WAVETYPE0_INT32)
+			str += "32-bit integer"
+		endif
+		if(type0 & IUTF_WAVETYPE0_INT64)
+			str += "64-bit integer"
+		endif
+		return str
+	else
+		type1 = WaveType(wv, 1)
+
+		if(type1 == IUTF_WAVETYPE1_NULL)
+			return "null wave"
+		endif
+		if(type1 == IUTF_WAVETYPE1_TEXT)
+			return "text wave"
+		endif
+		if(type1 == IUTF_WAVETYPE1_DFR)
+			return "DFREF wave"
+		endif
+		if(type1 == IUTF_WAVETYPE1_WREF)
+			return "WAVE REF wave"
+		endif
+	endif
+
+	return "UNKNOWN wave type"
+End
+
+/// This function assumes that EqualWaves(wv1, wv2, WAVE_DATA, tol) != 1.
+static Function/S DetermineWaveDataDifference(wv1, wv2, tol)
+	WAVE/Z wv1, wv2
+	variable tol
+
+	string msg
+	variable isComplex1, isComplex2
+	string wvName1, wvName2
+	string wvNamePrefix, tmpStr1, tmpStr2
+
+	// Generate names for reference
+	if(WaveExists(wv1))
+		wvName1 = GetWaveNameInDFStr(wv1)
+	else
+		wvName1 = "_null_"
+	endif
+	if(WaveExists(wv2))
+		wvName2 = GetWaveNameInDFStr(wv2)
+	else
+		wvName2 = "_null_"
+	endif
+	wvNamePrefix = "Wave1: " + wvName1 + "\rWave2: " + wvName2 + "\r"
+
+	// Size Check
+	Make/FREE/D wv1Dims = {DimSize(wv1, UTF_ROW), DimSize(wv1, UTF_COLUMN), DimSize(wv1, UTF_LAYER), DimSize(wv1, UTF_CHUNK)}
+	Make/FREE/D wv2Dims = {DimSize(wv2, UTF_ROW), DimSize(wv2, UTF_COLUMN), DimSize(wv2, UTF_LAYER), DimSize(wv2, UTF_CHUNK)}
+	if(!EqualWaves(wv1Dims, wv2Dims, WAVE_DATA, 0))
+		Make/FREE/T/N=(2, 1) table
+		wfprintf tmpStr1,"[%d]", wv1Dims
+		wfprintf tmpStr2,"[%d]", wv2Dims
+		table[0][0] = tmpStr1
+		table[1][0] = tmpStr2
+		msg = NicifyTableText(table, "Dimension Sizes;")
+		sprintf msg, "Waves differ in dimension sizes\r%s%s", wvNamePrefix, msg
+		return msg
+	endif
+
+	// complex type
+	isComplex1 = WaveType(wv1) & IUTF_WAVETYPE0_CMPL
+	isComplex2 = WaveType(wv2) & IUTF_WAVETYPE0_CMPL
+	if(isComplex1 != isComplex2)
+		Make/FREE/T/N=(2, 1) table
+		table[0][0] = GetTypeStrFromWaveType(wv1)
+		table[1][0] = GetTypeStrFromWaveType(wv2)
+		msg = NicifyTableText(table, "Wave Types;")
+		sprintf msg, "Waves differ in complex number type\r%s%s", wvNamePrefix, msg
+		return msg
+	endif
+
+	// Data Check
+	Make/FREE/T/N=(2 * UTF_MAXDIFFCOUNT, 3) table
+	SetDimLabel UTF_COLUMN, 0, DIMS, table
+	SetDimLabel UTF_COLUMN, 1, DIMLABEL, table
+	SetDimLabel UTF_COLUMN, 2, ELEMENT, table
+	IterateOverWaves(table, wv1, wv2, wv1Dims[0], wv1Dims[1], wv1Dims[2], wv1Dims[3], tol)
+	if(WaveType(wv1, 1) & IUTF_WAVETYPE1_TEXT)
+		msg = NicifyTableText(table, "Dimensions;Labels;Text;")
+		return "Text waves difference:\r" + wvNamePrefix + msg
+	else
+		msg = NicifyTableText(table, "Dimensions;Labels;Value;")
+		if(tol != 0)
+			sprintf tmpStr1, "Waves difference (tolerance limit %15f):\r", tol
+		else
+			tmpStr1 = "Waves difference:\r"
+		endif
+		return tmpStr1 + wvNamePrefix + msg
+	endif
+
+	return ""
+End
+
+static Function IterateOverWaves(table, wv1, wv2, rows, cols, layers, chunks, tol)
+	WAVE/T table
+	WAVE wv1, wv2
+	variable rows, cols, layers, chunks, tol
+
+	variable i, j, k, l
+	variable locCount
+	variable runTol
+
+	if(chunks)
+		for(l = 0; l < chunks; l += 1)
+			for(k = 0; k < layers; k += 1)
+				for(j = 0; j < cols; j += 1)
+					for(i = 0; i < rows; i += 1)
+						AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, runTol, tol)
+						if(locCount == UTF_MAXDIFFCOUNT)
+							return NaN
+						endif
+					endfor
+				endfor
+			endfor
+		endfor
+	elseif(layers)
+		for(k = 0; k < layers; k += 1)
+			for(j = 0; j < cols; j += 1)
+				for(i = 0; i < rows; i += 1)
+					AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, runTol, tol)
+					if(locCount == UTF_MAXDIFFCOUNT)
+						return NaN
+					endif
+				endfor
+			endfor
+		endfor
+	elseif(cols)
+		for(j = 0; j < cols; j += 1)
+			for(i = 0; i < rows; i += 1)
+				AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, runTol, tol)
+				if(locCount == UTF_MAXDIFFCOUNT)
+					return NaN
+				endif
+			endfor
+		endfor
+	else
+		for(i = 0; i < rows; i += 1)
+			AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, runTol, tol)
+			if(locCount == UTF_MAXDIFFCOUNT)
+				return NaN
+			endif
+		endfor
+	endif
+
+	Redimension/N=(2 * locCount, -1) table
+	return NaN
+End
+
+static Function/S GetWaveNameInDFStr(w)
+	WAVE w
+
+	string str, tmpStr
+	variable err
+
+	str = NameOfWave(w)
+	if(WaveType(w, 2) != IUTF_WAVETYPE2_FREE)
+		str += " in " + GetWavesDataFolder(w, 1)
+	else
+		Make/FREE/WAVE/N=1 wRef
+		wRef[0] = w
+		WAVE wNum = wRef
+#if IgorVersion() < 9.00
+		sprintf tmpStr, "0x08%x", wNum[0]
+#else
+		if(GetRTError(0))
+			tmpStr = "_free_"
+		else
+			sprintf tmpStr, "0x08%x", wNum[0]; err = GetRTError(1)
+		endif
+#endif
+		str = tmpStr
+	endif
+
+	return str
+End
+
+static Function ValueEqualInclNaN(v1, v2)
+	variable v1, v2
+
+	variable isNaN1, isNaN2, isInf1, isInf2, isnegInf1, isnegInf2
+
+	isNaN1 = IsNaN(v1)
+	isNaN2 = IsNaN(v2)
+	if(isNaN1 && isNaN2)
+		return 1
+	endif
+	isInf1 = v1 == Inf
+	isInf2 = v2 == Inf
+	if(isInf1 && isInf2)
+		return 1
+	endif
+	isnegInf1 = v1 == -Inf
+	isnegInf2 = v2 == -Inf
+	if(isnegInf1 && isnegInf2)
+		return 1
+	endif
+	if(v1 == v2)
+		return 1
+	endif
+
+	return 0
+End
+
+static Function/S SPrintWaveElement(w, row, col, layer, chunk)
+	WAVE w
+	variable row, col, layer, chunk
+
+	string str, tmpStr
+	variable err
+	variable majorType = WaveType(w, 1)
+	variable minorType = WaveType(w)
+
+	if(majorType == IUTF_WAVETYPE1_NUM)
+		if(minorType & IUTF_WAVETYPE0_CMPL)
+			if(minorType & (IUTF_WAVETYPE0_INT8 | IUTF_WAVETYPE0_INT16 | IUTF_WAVETYPE0_INT32))
+				Make/FREE/N=1/C/Y=(WaveType(w)) wTmp
+				wTmp[0] = w[row][col][layer][chunk]
+				if(minorType & IUTF_WAVETYPE0_USGN)
+					wfprintf str, "(%u, %u)", wTmp
+				else
+					wfprintf str, "(%d, %d)", wTmp
+				endif
+			elseif(minorType & IUTF_WAVETYPE0_INT64)
+#if IgorVersion() >= 7.00
+				if(minorType & IUTF_WAVETYPE0_USGN)
+					WAVE/C/L/U wCLU = w
+					Make/FREE/N=1/C/L/U wTmpCLU
+					wTmpCLU[0] = wCLU[row][col][layer][chunk]
+					wfprintf str, "(%u, %u)", wTmpCLU
+				else
+					WAVE/C/L wCLS = w
+					Make/FREE/N=1/C/L wTmpCLS
+					wTmpCLS[0] = wCLS[row][col][layer][chunk]
+					wfprintf str, "(%d, %d)", wTmpCLS
+				endif
+#endif
+			else
+				Make/FREE/N=1/C/Y=(WaveType(w)) wTmp
+				wTmp[0] = w[row][col][layer][chunk]
+				wfprintf str, "(%f, %f)", wTmp
+			endif
+		else
+			if(minorType & (IUTF_WAVETYPE0_INT8 | IUTF_WAVETYPE0_INT16 | IUTF_WAVETYPE0_INT32))
+				if(minorType & IUTF_WAVETYPE0_USGN)
+					sprintf str, "%u", w[row][col][layer][chunk]
+				else
+					sprintf str, "%d", w[row][col][layer][chunk]
+				endif
+			elseif(minorType & IUTF_WAVETYPE0_INT64)
+#if IgorVersion() >= 7.00
+				if(minorType & IUTF_WAVETYPE0_USGN)
+					WAVE/L/U wLU = w
+					sprintf str, "%u", wLU[row][col][layer][chunk]
+				else
+					WAVE/L wLS = w
+					sprintf str, "%d", wLS[row][col][layer][chunk]
+				endif
+#endif
+			else
+				sprintf str, "%f", w[row][col][layer][chunk]
+			endif
+		endif
+	elseif(majorType == IUTF_WAVETYPE1_TEXT)
+		WAVE/T wtext = w
+		str = AutoExtendedStringOutput(wtext[row][col][layer][chunk])
+	elseif(majorType == IUTF_WAVETYPE1_DFR)
+		WAVE/DF wdfref = w
+		tmpStr = GetDataFolder(1, wdfref[row][col][layer][chunk])
+		if(IsEmpty(tmpStr))
+			tmpStr = "_null DFR_"
+		elseif(DataFolderRefStatus(wdfref[row][col][layer][chunk]) == 3)
+			tmpStr = "_free DFR_"
+		endif
+#if IgorVersion() < 9.00
+		sprintf str, "0x%08x : %s", w[row][col][layer][chunk], tmpStr
+#else
+		if(GetRTError(0))
+			str = "_free_"
+		else
+			sprintf str, "0x%08x : %s", w[row][col][layer][chunk], tmpStr; err = GetRTError(1)
+		endif
+#endif
+	elseif(majorType == IUTF_WAVETYPE1_WREF)
+		WAVE/WAVE wref = w
+		tmpStr = GetWavesDataFolder(wref[row][col][layer][chunk], 2)
+		if(IsEmpty(tmpStr))
+			tmpStr = "_free wave_"
+		endif
+#if IgorVersion() < 9.00
+		sprintf str, "0x%08x : %s", w[row][col][layer][chunk], tmpStr
+#else
+		if(GetRTError(0))
+			str = "_free_"
+		else
+			sprintf str, "0x%08x : %s", w[row][col][layer][chunk], tmpStr; err = GetRTError(1)
+		endif
+#endif
+	else
+		sprintf str, "Unknown wave type"
+	endif
+
+	return str
+End
+
+static Function AddValueDiffImpl(table, wv1, wv2, locCount, row, col, layer, chunk, runTol, tol)
+	WAVE/T table
+	WAVE wv1, wv2
+	variable &locCount
+	variable row, col, layer, chunk
+	variable &runTol
+	variable tol
+
+	variable type1, type2, baseType1, baseType2
+	variable isInt1, isInt2, isInt641, isInt642, isComplex, v1, v2, isText1
+	variable bothWref, bothDFref
+	variable curTol
+	variable/C c1, c2
+	string s1, s2, str
+#if IgorVersion() >= 7.0
+	INT64 cmpI64R
+#endif
+
+	baseType1 = WaveType(wv1, 1)
+	baseType2 = WaveType(wv2, 1)
+	type1 = WaveType(wv1)
+	type2 = WaveType(wv2)
+
+	bothWref = (baseType1 == IUTF_WAVETYPE1_WREF) && (baseType2 == IUTF_WAVETYPE1_WREF)
+	bothDFref = (baseType1 == IUTF_WAVETYPE1_DFR) && (baseType2 == IUTF_WAVETYPE1_DFR)
+	isText1 = baseType1 == IUTF_WAVETYPE1_TEXT
+	if(istext1)
+		WAVE/T wv1t = wv1
+		WAVE/T wv2t = wv2
+
+		s1 = wv1t[row][col][layer][chunk]
+		s2 = wv2t[row][col][layer][chunk]
+
+#if IgorVersion() >= 7.0
+		if(!CmpStr(s1, s2, 2))
+			return NaN
+		endif
+#else
+		Make/FREE/T s1w = {s1}
+		Make/FREE/T s2w = {s2}
+
+		if(EqualWaves(s1w, s2w, WAVE_DATA))
+			return NaN
+		endif
+#endif
+	elseif(bothWref)
+		WAVE/WAVE wWRef1 = wv1
+		WAVE/WAVE wWRef2 = wv2
+		if(WaveRefsEqual(wWRef1[row][col][layer][chunk], wWRef2[row][col][layer][chunk]))
+			return NaN
+		endif
+	elseif(bothDFref)
+		WAVE/DF wDFRef1 = wv1
+		WAVE/DF wDFRef2 = wv2
+		if(DataFolderRefsEqual(wDFRef1[row][col][layer][chunk], wDFRef2[row][col][layer][chunk]))
+			return NaN
+		endif
+	else
+		isInt1 = type1 & (IUTF_WAVETYPE0_INT8 | IUTF_WAVETYPE0_INT16 | IUTF_WAVETYPE0_INT32 | IUTF_WAVETYPE0_INT64)
+		isInt2 = type2 & (IUTF_WAVETYPE0_INT8 | IUTF_WAVETYPE0_INT16 | IUTF_WAVETYPE0_INT32 | IUTF_WAVETYPE0_INT64)
+		isInt641 = type1 & IUTF_WAVETYPE0_INT64
+		isInt642 = type2 & IUTF_WAVETYPE0_INT64
+		isComplex = type1 & IUTF_WAVETYPE0_CMPL
+
+		if(isInt1 && isInt2)
+			// Int compare
+			if(isInt641 || isInt642)
+#if IgorVersion() >= 7.0
+				if(isComplex)
+					Make/FREE/C/L/N=1 wInt64Diff
+					wInt64Diff[0] = wv2[row][col][layer][chunk] - wv1[row][col][layer][chunk]
+					v1 = real(wInt64Diff[0])
+					v2 = imag(wInt64Diff[0])
+					if(!v1 && !v2)
+						return NaN
+					elseif(tol != 0)
+						curTol = v1 * v1 + v2 * v2
+					endif
+				else
+					cmpI64R = wv2[row][col][layer][chunk] - wv1[row][col][layer][chunk]
+					if(!cmpI64R)
+						return NaN
+					elseif(tol != 0)
+						curTol = cmpI64R * cmpI64R
+					endif
+				endif
+#endif
+			else
+				if(isComplex)
+					c1 = wv2[row][col][layer][chunk] - wv1[row][col][layer][chunk]
+					v1 = real(c1)
+					v2 = imag(c1)
+					if(!v1 && !v2)
+						return NaN
+					elseif(tol != 0)
+						curTol = v1 * v1 + v2 * v2
+					endif
+				else
+					v1 = wv1[row][col][layer][chunk]
+					v2 = wv2[row][col][layer][chunk]
+					if(v1 == v2)
+						return NaN
+					elseif(tol != 0)
+						curTol = (v1 - v2) * (v1 - v2)
+					endif
+				endif
+			endif
+		else
+			// FP compare
+			if(isComplex)
+				c1 = wv1[row][col][layer][chunk]
+				c2 = wv2[row][col][layer][chunk]
+				if(ValueEqualInclNaN(real(c1), real(c2)) && ValueEqualInclNaN(imag(c1), imag(c2)))
+					return NaN
+				elseif(tol != 0)
+					v1 = GetToleranceValues(real(c1), real(c2))
+					v1 = IsFinite(v1) ? real(c1) - real(c2) : Inf
+					v2 = GetToleranceValues(imag(c1), imag(c2))
+					v2 = IsFinite(v1) ? imag(c1) - imag(c2) : Inf
+					curTol = v1 * v1 + v2 * v2
+				endif
+			else
+				v1 = wv1[row][col][layer][chunk]
+				v2 = wv2[row][col][layer][chunk]
+				if(ValueEqualInclNaN(v1, v2))
+					return NaN
+				elseif(tol != 0)
+					curTol = GetToleranceValues(v1, v2)
+				endif
+			endif
+		endif
+	endif
+
+	if(!(istext1 | bothWref | bothDFref))
+		runTol += curTol
+		if(runTol < tol)
+			return NaN
+		endif
+	endif
+
+	sprintf str, "[%d][%d][%d][%d]", row, col, layer, chunk
+	table[2 * locCount][%DIMS] = str
+	Make/FREE/T wDL1 = {GetDimLabel(wv1, UTF_ROW, row), GetDimLabel(wv1, UTF_COLUMN, col), GetDimLabel(wv1, UTF_LAYER,layer), GetDimLabel(wv1, UTF_CHUNK, chunk)}
+	str = wDL1[0] + wDL1[1] + wDL1[2] + wDL1[3]
+	if(!IsEmpty(str))
+		sprintf str, "%s;%s;%s;%s;", wDL1[0], wDL1[1], wDL1[2], wDL1[3]
+		table[2 * locCount][%DIMLABEL] = str
+	endif
+	Make/FREE/T wDL2 = {GetDimLabel(wv2, UTF_ROW, row), GetDimLabel(wv2, UTF_COLUMN, col), GetDimLabel(wv2, UTF_LAYER,layer), GetDimLabel(wv2, UTF_CHUNK, chunk)}
+	str = wDL2[0] + wDL2[1] + wDL2[2] + wDL2[3]
+	if(!IsEmpty(str))
+		sprintf str, "%s;%s;%s;%s;", wDL2[0], wDL2[1], wDL2[2], wDL2[3]
+		table[2 * locCount + 1][%DIMLABEL] = str
+	endif
+	table[2 * locCount][%ELEMENT] = SPrintWaveElement(wv1, row, col, layer, chunk)
+	table[2 * locCount + 1][%ELEMENT] = SPrintWaveElement(wv2, row, col, layer, chunk)
+
+	locCount += 1
+End
+
+// This function assumes that v1 != v2 and not both are NaN
+static Function GetToleranceValues(v1, v2)
+	variable v1, v2
+
+	variable isNaN1, isNaN2, isInf1, isInf2, isnegInf1, isnegInf2
+
+	isNaN1 = IsNaN(v1)
+	isNaN2 = IsNaN(v2)
+	if(isNaN1 || isNaN2)
+		return Inf
+	endif
+	isInf1 = v1 == Inf
+	isInf2 = v2 == Inf
+	if(isInf1 != isInf2)
+		return Inf
+	endif
+	isnegInf1 = v1 == -Inf
+	isnegInf2 = v2 == -Inf
+	if(isnegInf1 != isnegInf2)
+		return Inf
+	endif
+
+	return (v1 - v2) * (v1 - v2)
+End
+
+static Function/S NicifyTableText(table, titleList)
+	WAVE/T table
+	string titleList
+
+	variable numCols, numRows, i, j, padVal
+	string str
+
+	InsertPoints/M=(UTF_ROW) 0, 2, table
+	numCols = min(DimSize(table, UTF_COLUMN), ItemsInList(titleList))
+	for(i = 0; i < numCols; i += 1)
+		table[0][i] = StringFromList(i, titleList)
+	endfor
+
+	numCols = DimSize(table, UTF_COLUMN)
+	numRows = DimSize(table, UTF_ROW)
+	Make/FREE/N=(numRows, numCols)/D strSizes
+
+	strSizes = strlen(table[p][q])
+
+	for(j = 0; j < numRows; j += 1)
+		padVal = j == 1 ? 0x2d : 0x20
+		for(i = 0; i < numCols; i += 1)
+#if IgorVersion() >= 7.00
+			WaveStats/Q/M=1/RMD=[][i, i] strSizes
+#else
+			Make/FREE/N=(DimSize(strSizes, UTF_ROW)) strSizeCol
+			strSizeCol[] = strSizes[p][i]
+			WaveStats/Q/M=1 strSizeCol
+#endif
+			table[j][i] = PadString(table[j][i], V_Max, padVal)
+		endfor
+	endfor
+
+	str = ""
+	for(j = 0; j < numRows; j += 1)
+		for(i = 0; i < numCols; i += 1)
+			str += table[j][i] + "|"
+		endfor
+		str += "\r"
+	endfor
+
+	return str
+End
+
+/// @brief Based on DisplayHelpTopic "Character-by-Character Operations"
+static Function NumBytesInUTF8Character(str, byteOffset)
+	string str
+	variable byteOffset
+
+	variable firstByte
+	variable numBytesInString = strlen(str)
+
+	if(byteOffset < 0 || byteOffset >= numBytesInString)
+		return 0
+	endif
+
+	firstByte = char2num(str[byteOffset]) & 0xFF
+
+	if(firstByte < 0x80)
+		return 1
+	endif
+
+	if(firstByte >= 0xC2 && firstByte <= 0xDF)
+		return 2
+	endif
+
+	if(firstByte >= 0xE0 && firstByte <= 0xEF)
+		return 3
+	endif
+
+	if(firstByte >= 0xF0 && firstByte <= 0xF4)
+		return 4
+	endif
+
+	// Invalid UTF8 code point
+	return 1
+End
+
+#if IgorVersion() >= 7.00
+static Function/S AutoExtendedStringOutput(str)
+	string str
+
+	variable bytePos, charNum, numBytes, code
+	variable extPrint, len
+	string format, hexOut
+	string extOut = ""
+
+	Make/FREE/I/U biDiChars = { \
+							char2num("\u200E"), char2num("\u200F"), char2num("\u061C"), char2num("\u202A"), \
+							char2num("\u202D"), char2num("\u202B"), char2num("\u202E"), char2num("\u202C"), \
+							char2num("\u2066"), char2num("\u2067"), char2num("\u2068"), char2num("\u2069")}
+
+	len = strlen(str)
+	if(len)
+		do
+			numBytes = NumBytesInUTF8Character(str, bytePos)
+			code = char2num(str[bytePos, bytePos + numBytes - 1])
+			if(code >= char2num("\u0000") && code <= char2num("\u001F"))
+				// C0 controls
+				extPrint = 1
+			elseif(code >= char2num("\u007F") && code <= char2num("\u009F"))
+				// C1 controls
+				extPrint = 1
+			else
+				// Bi Directional characters
+				FindValue/V=(code) biDiChars
+				if(V_Value >= 0)
+					extPrint = 1
+				endif
+			endif
+			format = "%0" + num2str(2 * numBytes) + "x"
+			sprintf hexOut, format, code
+			extOut += hexOut + " "
+			bytePos += numBytes
+		while(bytePos < len)
+	endif
+
+	return SelectString(extPrint, str, ": " + extOut)
+End
+#else
+static Function/S AutoExtendedStringOutput(str)
+	string str
+
+	variable bytePos, code
+	variable extPrint, len
+	string format, hexOut
+	string extOut = ""
+
+	len = strlen(str)
+	for(bytePos = 0; bytePos < len; bytePos += 1)
+		code = char2num(str[bytePos]) & 0x7F
+		if(code >= 0 && code <= 31)
+			extPrint = 1
+		elseif(code == 127)
+			extPrint = 1
+		endif
+		sprintf hexOut, "%02x", code
+		extOut += hexOut + " "
+	endfor
+
+	return SelectString(extPrint, str, ": " + extOut)
+End
+#endif

--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -201,8 +201,9 @@ End
 /// We return a fixed string if it is null and limit its size so that it can be used in a sprintf statement using plain
 /// "%s". We also do that for IP9, where this limit does not exist anymore, to have a consistent output across all IP
 /// versions.
-static Function/S PrepareStringForOut(str)
+static Function/S PrepareStringForOut(str, [maxLen])
 	string &str
+	variable maxLen
 
 	variable length
 	string suffix
@@ -211,14 +212,16 @@ static Function/S PrepareStringForOut(str)
 		return "(null)"
 	endif
 
+	maxLen = ParamIsDefault(maxLen) ? MAX_STRING_LENGTH : maxLen
+
 	length = strlen(str)
 
-	if(length < MAX_STRING_LENGTH)
+	if(length < maxLen)
 		return str
 	endif
 
 	suffix = ".."
-	return str[0, MAX_STRING_LENGTH - 1 - strlen(suffix)] + suffix
+	return str[0, maxLen - 1 - strlen(suffix)] + suffix
 End
 
 ///@endcond // HIDDEN_SYMBOL

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -273,9 +273,19 @@ static Function TestUTF()
 	// @{
 	string detailedMsg
 	Make/FREE numData1, numData2
-	Ensure(!UTF_Checks#AreWavesEqual($"", $"", WAVE_DATA, DEFAULT_TOLERANCE, detailedMsg))
-	Ensure(!UTF_Checks#AreWavesEqual(numData1, $"", WAVE_DATA, DEFAULT_TOLERANCE, detailedMsg))
-	Ensure(!UTF_Checks#AreWavesEqual($"", numData2, WAVE_DATA, DEFAULT_TOLERANCE, detailedMsg))
+	// Null Waves are checked in the wrapper, call to test that no RTE comes up
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER($"", $"", !OUTPUT_MESSAGE)
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(numData1, $"", !OUTPUT_MESSAGE)
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER($"", numData2, !OUTPUT_MESSAGE)
+	// different type zero sized waves
+	Make/FREE/N=0/D wNumType1
+	Make/FREE/N=0/I wNumType2
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(wNumType1, wNumType2, !OUTPUT_MESSAGE)
+	// different basic type waves
+	Make/FREE/N=1/D wNumType1
+	Make/FREE/WAVE wWRrefType = {wNumType1}
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(wNumType1, wWRrefType, !OUTPUT_MESSAGE)
+
 	Ensure(UTF_Checks#AreWavesEqual(numData1, numData2, WAVE_DATA, DEFAULT_TOLERANCE, detailedMsg))
 	Ensure(strlen(detailedMsg) == 0)
 	Ensure(UTF_Checks#AreWavesEqual(numData1, numData2, ALL_MODES, DEFAULT_TOLERANCE, detailedMsg))
@@ -288,10 +298,10 @@ static Function TestUTF()
 	Ensure(UTF_Checks#AreWavesEqual(textData1, textData2, ALL_MODES, DEFAULT_TOLERANCE, detailedMsg))
 	Ensure(strlen(detailedMsg) == 0)
 	// If the following invalid tol or mode is improperly checked the function fails with an uncaught RTE
-	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, 0, mode = WAVE_DATA, tol = NaN)
-	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, 0, mode = WAVE_DATA, tol = -1)
-	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, 0, mode = NaN, tol = DEFAULT_TOLERANCE)
-	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, 0, mode = 0x10000000, tol = DEFAULT_TOLERANCE)
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, !OUTPUT_MESSAGE, mode = WAVE_DATA, tol = NaN)
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, !OUTPUT_MESSAGE, mode = WAVE_DATA, tol = -1)
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, !OUTPUT_MESSAGE, mode = NaN, tol = DEFAULT_TOLERANCE)
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, !OUTPUT_MESSAGE, mode = 0x10000000, tol = DEFAULT_TOLERANCE)
 	// @}
 
 	// AreWavesEqual


### PR DESCRIPTION
When the data in two waves differ, AreWavesEqual now gives information
where the first and the last difference occured.
FindDifferentWaveEntries, GetWaveIndexInfo and GetWaveDimension funtions
were added in order to work.

Remark: In FindDifferentWaveEntries the built-in function FindLevel was not used, as it returns NAN if already the first element is above the tolerance, or if no element is above the tolerance. That would require an additional step, even though it would be simple if we can assume the second case is impossible because the waves are not equal.

Closes #30 