### PR TITLE
Bugfix TAP now also outputs skipped testcases

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -2630,9 +2630,9 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 				s.tcSuffix = ""
 			endif
 
-			if(!s.tap_skipCase || reentry)
+			do
 
-				do
+				if(!s.tap_skipCase || reentry)
 
 					if(!reentry)
 
@@ -2708,13 +2708,16 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 						break
 					endif
 
-					TAP_WriteCaseIfReq(s.tap_caseCount, s.tap_skipCase)
-					s.tap_caseCount += 1
+				else
+					TAP_SetDirectiveAndDescription(s.fullFuncName)
+				endif
+				
+				TAP_WriteCaseIfReq(s.tap_caseCount, s.tap_skipCase)
+				s.tap_caseCount += 1
 
-					s.dgenIndex += 1
-				while(s.mdMode && s.dgenIndex < s.dgenSize)
+				s.dgenIndex += 1
 
-			endif
+			while(s.mdMode && s.dgenIndex < s.dgenSize)
 
 		endfor
 

--- a/procedures/unit-testing-tap.ipf
+++ b/procedures/unit-testing-tap.ipf
@@ -241,11 +241,11 @@ static Function TAP_WriteCase(case_cnt, skipcase)
 
 	if(skipcase)
 		str_ok = "ok"
+		tap_diagnostic = ""
 	else
 		str_ok = SelectString(tap_caseErr == 0, "not ok", "ok")
+		tap_diagnostic = TAP_ValidDiagnostic(tap_diagnostic)
 	endif
-
-	tap_diagnostic = TAP_ValidDiagnostic(tap_diagnostic)
 
 	// Write Out Test Case Result, TAP counts starting with 1
 	sprintf str_out, "%s %d %s %s" + TAP_LINEEND_STR, str_ok, case_cnt, tap_description, tap_directive


### PR DESCRIPTION
If a test case was skipped, it would not appear in TAP output.
Now it gets numbered and marked as OK.