### PR TITLE
Bugfix: Mistake from commit a3ab7ca8 fixed

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -2709,7 +2709,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 					endif
 
 				else
-					TAP_SetDirectiveAndDescription(s.fullFuncName)
+					TAP_GetNotes(s.fullFuncName)
 				endif
 				
 				TAP_WriteCaseIfReq(s.tap_caseCount, s.tap_skipCase)


### PR DESCRIPTION
In commit a3ab7ca8 a function was used which was not already implemented
in master, thus breaking UTF. This function was substituted by the function
already in master.

Tests in CI pipeline succeeded.