### PR TITLE
.gitlab-ci.yml: Update our documentation toolchain

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ documentation:
     - debian, docker
   stage: build
   image:
-    name: ${CI_REGISTRY}/internal/docker-sphinx:latest
+    name: ${CI_REGISTRY}/internal/docker-sphinx:update-to-sphinx-3
   script:
     - cd docu/doxygen
     - doxygen


### PR DESCRIPTION
Now with sphinx 3.0.0, breathe 4.15 and sphinxcontrib-images 0.9.2.

- [ ] Change to latest back once that is updated

Close #124.