### PR TITLE
Matomo: Use the compressed javascript version

### DIFF
--- a/docu/sphinx/source/_static/js/matomo.js
+++ b/docu/sphinx/source/_static/js/matomo.js
@@ -9,5 +9,5 @@ _paq.push(['enableLinkTracking']);
   _paq.push(['setTrackerUrl', u+'matomo.php']);
   _paq.push(['setSiteId', '1']);
   var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'js/index.php'; s.parentNode.insertBefore(g,s);
 })();


### PR DESCRIPTION
This loads faster than the uncompressed one. See
https://github.com/matomo-org/matomo/tree/4.x-dev/js for the
documentation.