### PR TITLE
CheckFunctionSignaturesTC: Abort on invalid data generator functions

### DIFF
--- a/docu/sphinx/source/advanced.rst
+++ b/docu/sphinx/source/advanced.rst
@@ -286,7 +286,7 @@ The data generator function name must be attributed with a comment within four
 lines above the test cases Function line. The key word is `UTF_TD_GENERATOR` with
 the data generators function name following as seen in the simple example here.
 If no data generator is given or the format of the test case function does not fit
-to the wave type then a error message is printed and the test case is ignored.
+to the wave type then a error message is printed and the test run is aborted.
 
 The test case names are by default extended with `:num` where num is the index
 of the wave returned from the data generator. For convenience in the data generator

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -1356,33 +1356,33 @@ static Function/S CheckFunctionSignaturesTC(testCaseList, procWin)
 		if(err)
 			sprintf msg, "Could not find data generator specification for multi data test case %s. %s", fullTestCase, dgen
 			UTF_PrintStatusMessage(msg)
-			continue
+			Abort msg
 		else
 			dgen = getFullFunctionName(err, dgen, procWin)
 			if(err)
 				sprintf msg, "Could not get full function name of data generator: %s", dgen
 				UTF_PrintStatusMessage(msg)
-				continue
+				Abort msg
 			endif
 			FUNCREF TEST_CASE_PROTO_DGEN fDgen = $dgen
 			if(!UTF_FuncRefIsAssigned(FuncRefInfo(fDgen)))
 				sprintf msg, "Data Generator function %s has wrong format. It is referenced by test case %s.", dgen, fullTestCase
 				UTF_PrintStatusMessage(msg)
-				continue
+				Abort msg
 			endif
 			WAVE/Z wGenerator = fDgen()
 			if(!WaveExists(wGenerator))
 				sprintf msg, "Data Generator function %s returns a null wave. It is referenced by test case %s.", dgen, fullTestCase
 				UTF_PrintStatusMessage(msg)
-				continue
+				Abort msg
 			elseif(DimSize(wGenerator, 1) > 0)
 				sprintf msg, "Data Generator function %s returns not a 1D wave. It is referenced by test case %s.", dgen, fullTestCase
 				UTF_PrintStatusMessage(msg)
-				continue
+				Abort msg
 			elseif(!((wType1 == WAVETYPE1_NUM && WaveType(wGenerator, 1) == wType1 && WaveType(wGenerator) & wType0) || (wType1 != WAVETYPE1_NUM && WaveType(wGenerator, 1) == wType1)))
 				sprintf msg, "Data Generator %s functions returned wave format does not fit to expected test case parameter. It is referenced by test case %s.", dgen, fullTestCase
 				UTF_PrintStatusMessage(msg)
-				continue
+				Abort msg
 			elseif(!DimSize(wGenerator, 0))
 				sprintf msg, "Data Generator function %s returns a wave with zero points. It is referenced by test case %s.", dgen, fullTestCase
 				UTF_PrintStatusMessage(msg)


### PR DESCRIPTION
Ever since the introduction of multi data test cases we only warned when
the data generator function could not be used.

This hides buggy test setups and is there bad.

So let's abort in these cases.

The case of an empty generator wave will be handled separately.

Close #99 

@MichaelHuth I went for the abort solution you suggested in https://github.com/byte-physics/igor-unit-testing-framework/pull/131#pullrequestreview-415353210.