### PR TITLE
docu/sphinx/source/conf.py: Use non-deprecated method call

### DIFF
--- a/docu/sphinx/source/conf.py
+++ b/docu/sphinx/source/conf.py
@@ -133,7 +133,7 @@ html_sidebars = {
 
 # open javascript analytics: https://matomo.org/
 def setup(app):
-    app.add_javascript('js/matomo.js')
+    app.add_js_file('js/matomo.js')
 
 # -- Options for HTMLHelp output ---------------------------------------------
 


### PR DESCRIPTION
.../conf.py:205:
RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please
use app.add_js_file() instead.
  app.add_javascript('js/matomo.js')