### PR TITLE
.gitlab-ci.yml: Only fetch the submodules when needed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,6 @@
 # This file is a template, and might need editing before it works on your project.
 # see https://docs.gitlab.com/ce/ci/yaml/README.html for all available options
 
-variables:
-  GIT_SUBMODULE_STRATEGY: "recursive"
-
 stages:
   - build
   - deploy
@@ -14,6 +11,7 @@ documentation:
   stage: build
   variables:
     DOCKER_AUTH_CONFIG: "${DOCKER_AUTH_CONFIG_SPHINX}"
+    GIT_SUBMODULE_STRATEGY: "recursive"
   image:
     name: ${CI_REGISTRY}/internal/docker-sphinx:latest
   script:


### PR DESCRIPTION
We only need the submodules for building the documentation.

This speeds up CI.