### PR TITLE
Fix: Do not enforce Datagenerator function to be static in same procedure.

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -818,10 +818,13 @@ static Function/S GetDataGeneratorFunctionName(err, funcName, procName)
 	if(!UTF_Utils#IsEmpty(infoStr))
 		modName = StringByKey("MODULE", infoStr)
 		pName = StringByKey("NAME", infoStr)
-		if(CmpStr(StringByKey("SPECIAL", infoStr), "static"))
-			sprintf errMsg, "Data Generator Function %s#%s must be static.", modName, pName
+		if(!CmpStr(StringByKey("SPECIAL", infoStr), "static") && UTF_Utils#IsEmpty(modName))
+			sprintf errMsg, "Data Generator Function %s is declared static but the procedure file %s is missing a \"#pragma ModuleName=myName\" declaration.", pName, procName
 			err = 1
 			return errMsg
+		endif
+		if(UTF_Utils#IsEmpty(modName))
+			return pName
 		endif
 		return modName + "#" + pName
 	else


### PR DESCRIPTION
In commit 98f58595e5dfd130d7b1d8e44f728724e70bca6e it was introduced that the
data generator function was enforced to be static when it was present in the
same procedure file.

However when the function is static then the procedure must have a Module
specification. Thus, the logic was changed that it gives an error only if
a static function was found without Module specification.
Also without Module specification (for non-static functions) only the function
name is returned.

Also note that FunctionInfo does not find static functions in other procedure files when called with the function name specification only. So the check is not necessary for the else part.

close https://github.com/byte-physics/igor-unit-testing-framework/issues/175