### PR TITLE
Enforce assertion in test case, not counting assertions from test hooks

### DIFF
--- a/docu/sphinx/source/advanced.rst
+++ b/docu/sphinx/source/advanced.rst
@@ -78,6 +78,9 @@ cleanup is done afterward. The *next* Test Case then starts with the data the
 .. note::
    By default the Igor debugger is disabled during the execution of a test run.
 
+Assertions can be used in test hooks. However it is enforced by the IUTF that
+the test case itself must contain at least one assertion.
+
 .. _JUNITOutput:
 
 JUNIT Output

--- a/internal_dev/TestCaseAssertionCounterCheck.ipf
+++ b/internal_dev/TestCaseAssertionCounterCheck.ipf
@@ -1,0 +1,28 @@
+#pragma TextEncoding = "UTF-8"
+#pragma rtGlobals=3		// Use modern global access method and strict wave access.
+#pragma rtFunctionErrors=1
+
+#include "unit-testing"
+
+// RunTest("TestCaseAssertionCounterCheck.ipf")
+
+// If this test fails then everything works correct,
+// as the assertions in the hooks must not count as test case assertions.
+
+Function TEST_CASE_BEGIN_OVERRIDE(name)
+	string name
+
+	print "Hook TC Begin called"
+	PASS()
+End
+
+Function TEST_CASE_END_OVERRIDE(name)
+	string name
+
+	print "Hook TC End called"
+	PASS()
+End
+
+Function myTestCase()
+	// no Assertion here
+End


### PR DESCRIPTION
Only assertions in the test case are counted when enforcing at least one assertion per test case.
A test case spans all code after test case begin to test case end including possible reentry functions.

close https://github.com/byte-physics/igor-unit-testing-framework/issues/113