### PR TITLE
gitlab-ci.yml: Adapt deployment job for new default branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,7 @@ deployment:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_COMMIT_BRANCH == "main"'
       when: on_success
   tags:
     - debian, docker


### PR DESCRIPTION
The default branch changed to main sometime ago, but here we still
reference master.