### PR TITLE
Introduced typed waves for multi data test cases

### DIFF
--- a/docu/sphinx/source/advanced.rst
+++ b/docu/sphinx/source/advanced.rst
@@ -321,6 +321,15 @@ The optional argument of the test case function is always given from the data
 generator wave elements. Thus the case that `ParamIsDefault(arg)` is true never
 happens.
 
+When setting up a multi data test case with a data generator returning wave
+references then the test case can also use typed waves. Supported are
+text waves (``WAVE/T``), waves with data folder references (``WAVE/DF``) and
+waves with wave references (``WAVE/WAVE``). For such a test case or reentry
+function the associated data generator must return a wave reference wave where
+each wave element refers to a wave of the fitting type.
+For a test case setup with the generic ``WAVE`` the type is not fixed for all
+elements of from the data generator.
+
  See also :ref:`example13`.
 
 Multi Data Test Cases with Background Activity

--- a/internal_dev/DataGenSpecificWaveTypes.ipf
+++ b/internal_dev/DataGenSpecificWaveTypes.ipf
@@ -1,0 +1,112 @@
+#pragma rtGlobals=3
+#pragma rtFunctionErrors=1
+#pragma TextEncoding="UTF-8"
+
+#include "unit-testing"
+
+// RunTest("DataGenSpecificWaveTypes.ipf")
+
+Function/WAVE myMDGeneratorMulti()
+
+	Make/FREE/T wt = {"1"}
+	Make/FREE/D wNum
+
+// Including the following line in favor to the next has to result in a type error report
+//	Make/FREE/WAVE wref = {wt, wt, wNum}
+	Make/FREE/WAVE wref = {wt, wt}
+
+	return wref
+End
+
+Function/WAVE myMDGeneratorText()
+
+	Make/FREE/T wt = {"1"}
+	Make/FREE/WAVE wref = {wt, wt, wt}
+
+	return wref
+End
+
+Function/WAVE myMDGeneratorDFR()
+
+	Make/FREE/DF wdfr = {NewFreeDataFolder()}
+	Make/FREE/WAVE wref = {wdfr, wdfr, wdfr}
+
+	return wref
+End
+
+Function/WAVE myMDGeneratorWAVE()
+
+	Make/FREE w
+	Make/FREE/WAVE wWave = {w}
+	Make/FREE/WAVE wref = {wWave, wWave, wWave}
+
+	return wref
+End
+
+// UTF_TD_GENERATOR myMDGeneratorText
+Function myMDTestText([textWave])
+	WAVE/T textWave
+
+	Make/FREE/T w1 = {"1"}
+
+	CHECK_EQUAL_WAVES(w1, textWave, mode=WAVE_DATA)
+End
+
+// UTF_TD_GENERATOR myMDGeneratorText
+Function myMDTestGeneric([wv])
+	WAVE wv
+
+	WAVE/T textWave = wv
+	Make/FREE/T w1 = {"1"}
+
+	CHECK_EQUAL_WAVES(w1, textWave, mode=WAVE_DATA)
+End
+
+// UTF_TD_GENERATOR myMDGeneratorDFR
+Function myMDTestDFR([dfrWave])
+	WAVE/DF dfrWave
+
+	CHECK(DataFolderRefStatus(dfrWave[0]))
+End
+
+// UTF_TD_GENERATOR myMDGeneratorMulti
+Function myMDTestMulti([textWave])
+	WAVE/T textWave
+
+	Make/FREE/T w1 = {"1"}
+
+	CHECK_EQUAL_WAVES(w1, textWave, mode=WAVE_DATA)
+End
+
+// UTF_TD_GENERATOR myMDGeneratorWAVE
+Function myMDTestWAVEGeneric([wv])
+	WAVE wv
+
+	WAVE/WAVE wref = wv
+
+	CHECK(WaveExists(wref[0]))
+End
+
+// UTF_TD_GENERATOR myMDGeneratorWAVE
+Function myMDTestWAVE([wrefWave])
+	WAVE/WAVE wrefWave
+
+	CHECK(WaveExists(wrefWave[0]))
+	RegisterUTFMonitor("dummyTask", BACKGROUNDMONMODE_OR, "myMDTestWAVE1_REENTRY")
+End
+
+// UTF_TD_GENERATOR myMDGeneratorWAVE
+Function myMDTestWAVE1_REENTRY([wrefWave])
+	WAVE/WAVE wrefWave
+
+	CHECK(WaveExists(wrefWave[0]))
+	RegisterUTFMonitor("dummyTask", BACKGROUNDMONMODE_OR, "myMDTestWAVE2_REENTRY")
+End
+
+// UTF_TD_GENERATOR myMDGeneratorWAVE
+Function myMDTestWAVE2_REENTRY([wv])
+	WAVE wv
+
+	WAVE/WAVE wrefWave = wv
+	CHECK(WaveExists(wrefWave[0]))
+End

--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -220,3 +220,15 @@ static Function/S PrepareStringForOut(str)
 End
 
 ///@endcond // HIDDEN_SYMBOL
+
+/// @brief Returns 1 if all wave elements in wave reference wave wv are of type subType, 0 otherwise
+static Function HasConstantWaveTypes(wv, subType)
+	WAVE/WAVE wv
+	variable subType
+
+	Make/FREE/N=(DimSize(wv, UTF_ROW)) matches
+	MultiThread matches = WaveType(wv[p], 1) == subType
+
+	FindValue/V=(0) matches
+	return V_Value == -1
+End


### PR DESCRIPTION
In addition to the generic WAVE type multi data test cases also accept now
WAVE/T, WAVE/WAVE and WAVE/DF specific types.
The associated data generators must return waveRef waves where each element
must have the fitting type.

Added examples for all three new typed waves to DataGenSpecificWaveTypes.ipf
in internal_dev.

The MD test case data type setup is not internally buffered for each test case
found. This means that for the actual call to the test case the function
template is determined from the wave type of the element of the data generator
wave.
So for a data generator that returns a wave reference wave with text waves as
elements a test case with WAVE and with WAVE/T is valid. This applies to
reentry functions as well. See also the last example in
DataGenSpecificWaveTypes.ipf.
There is no priority applied as with a test case name only one declaration is
connected.

So the test cases entry function declaration puts constraints on the wave type of the elements from the wave reference wave from the data generator. Reentry functions are checked at runtime because they are also known through the registration. For these WAVE and the typed WAVE/xxx declaration might be valid, then both is checked and the call is done according to the found function declaration. Thus a test case entry when declared with WAVE/T constrains all elements from the data generator wave reference wave to text wave type. A following reentry function is valid with either WAVE or WAVE/T.

close https://github.com/byte-physics/igor-unit-testing-framework/issues/112