### PR TITLE
Fix for RTE cleanup in AreWavesEqual blocking TC RTE evaluation

### DIFF
--- a/procedures/unit-testing-assertion-checks.ipf
+++ b/procedures/unit-testing-assertion-checks.ipf
@@ -200,13 +200,7 @@ static Function AreWavesEqual(wv1, wv2, mode, tol, detailedMsg)
 
 	variable result, err
 
-	// handle NaN return values from EqualWaves for unknown modes
-	try
-		result = EqualWaves(wv1, wv2, mode, tol) == 1; AbortOnRTE
-	catch
-		err = GetRTError(1)
-		result = 0
-	endtry
+	result = EqualWaves(wv1, wv2, mode, tol) == 1
 
 	detailedMsg = ""
 

--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -667,11 +667,25 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 	if(ParamIsDefault(mode))
 		Make/I/FREE modes = { WAVE_DATA, WAVE_DATA_TYPE, WAVE_SCALING, DATA_UNITS, DIMENSION_UNITS, DIMENSION_LABELS, WAVE_NOTE, WAVE_LOCK_STATE, DATA_FULL_SCALE, DIMENSION_SIZES}
 	else
+		if(!UTF_Utils#IsFinite(mode))
+			EvaluateResults(0, "Valid mode for EQUAL_WAVE check.", flags)
+			return NaN
+		elseif(!(mode & (WAVE_DATA | WAVE_DATA_TYPE | WAVE_SCALING | DATA_UNITS | DIMENSION_UNITS | DIMENSION_LABELS | WAVE_NOTE | WAVE_LOCK_STATE | DATA_FULL_SCALE | DIMENSION_SIZES)))
+			EvaluateResults(0, "Valid mode for EQUAL_WAVE check.", flags)
+			return NaN
+		endif
+
 		Make/I/FREE modes = { mode }
 	endif
 
 	if(ParamIsDefault(tol))
 		tol = 0.0
+	elseif(UTF_Utils#IsNaN(tol))
+		EvaluateResults(0, "Valid tolerance for EQUAL_WAVE check.", flags)
+		return NaN
+	elseif(tol < 0)
+		EvaluateResults(0, "Valid tolerance for EQUAL_WAVE check.", flags)
+		return NaN
 	endif
 
 	for(i = 0; i < DimSize(modes, 0); i += 1)

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -30,6 +30,8 @@ End
 // One test case for everyting
 // This is done so that we don't rely on the UTF test case discovery logic to work.
 static Function TestUTF()
+	variable err
+
 	PASS()
 
 	// test VTEE's Ensure
@@ -278,8 +280,6 @@ static Function TestUTF()
 	Ensure(strlen(detailedMsg) == 0)
 	Ensure(UTF_Checks#AreWavesEqual(numData1, numData2, ALL_MODES, DEFAULT_TOLERANCE, detailedMsg))
 	Ensure(strlen(detailedMsg) == 0)
-	// unknown mode
-	Ensure(!UTF_Checks#AreWavesEqual(numData1, numData2, 0x10000000, DEFAULT_TOLERANCE, detailedMsg))
 
 	Make/FREE/T textData1, textData2
 	Ensure(UTF_Checks#AreWavesEqual(textData1, textData2, WAVE_DATA, DEFAULT_TOLERANCE, detailedMsg))
@@ -287,6 +287,11 @@ static Function TestUTF()
 	// all modes
 	Ensure(UTF_Checks#AreWavesEqual(textData1, textData2, ALL_MODES, DEFAULT_TOLERANCE, detailedMsg))
 	Ensure(strlen(detailedMsg) == 0)
+	// If the following invalid tol or mode is improperly checked the function fails with an uncaught RTE
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, 0, mode = WAVE_DATA, tol = NaN)
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, 0, mode = WAVE_DATA, tol = -1)
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, 0, mode = NaN, tol = DEFAULT_TOLERANCE)
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(textData1, textData2, 0, mode = 0x10000000, tol = DEFAULT_TOLERANCE)
 	// @}
 
 	// AreWavesEqual


### PR DESCRIPTION
A fix for invalid parameters for a EqualWaves call in the IUTF was introduced
in 28f7fc37221c117ae3d4a6e5baddd4dd549cc4bb

This created the problem that an RTE that happens in a test case is cleared
at this point in the IUTF and then the RTE gets not visible in the RTE
evaluation. Thus it gets ignored and does not raise an error.

The fix:
EqualWaves is still "monitored" with a AbortOnRTE but not within a try catch
block. If there is a lingering RTE or EqualWaves generates an RTE then the
catch block for the test case takes action and evaluates the RTE.
Thus, wrong parameter passed from CHECK_EQUAL_WAVES to IUTF EqualWaves raise
an RTE that looks like it originates from the test case itself. This is valid
because the CHECK_EQUAL_WAVES parameters are compatible with EqualWaves.

Also mode is checked in EQUAL_WAVE_WRAPPER for validity to abort early on
invalid modes. mode must have at least one valid bit set.