### PR TITLE
Add tests for correct notation of test case names

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -2,6 +2,7 @@
 #pragma rtFunctionErrors=1
 #pragma version=1.08
 #pragma TextEncoding="UTF-8"
+#pragma ModuleName=UTF_Basics
 
 // Licensed under 3-Clause BSD, see License.txt
 

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -529,4 +529,26 @@ static Function TestUTF()
 	CHECK_WAVE({0}, NUMERIC_WAVE, minorType = FLOAT_WAVE)
 
 	// @}
+
+	// TestCaseNameNotation
+	// @{
+
+	variable tmpVar1, tmpVar2
+	string thisProcName, tcList
+	thisProcName = ParseFilePath(0, FunctionPath("TestCaseNameTest2"), ":", 1, 0)
+	tcList = UTF_Basics#getTestCasesMatch(thisProcName, ".*", 1, tmpVar1, tmpVar2)
+	Ensure(WhichListItem("UTF_Tests#TestCaseNameTest1", tcList) >= 0)
+	Ensure(WhichListItem("TestCaseNameTest2", tcList) >= 0)
+
+	// @}
+End
+
+static Function TestCaseNameTest1()
+
+	PASS()
+End
+
+Function TestCaseNameTest2()
+
+	PASS()
 End


### PR DESCRIPTION
test calls getTestCaseMatch of the IUTF that calls
getFullFunctionName.

The tests checks if static functions are prepended by the module and
non-static function names have no module name prepended.

close https://github.com/byte-physics/igor-unit-testing-framework/issues/162