### PR TITLE
Function signatures of test cases are now checked after filtering them

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -1555,9 +1555,8 @@ static Function/S GetTestCaseList(procWin)
 	if(!UTF_Utils#IsEmpty(testCaseMDList))
 		testCaseList = testCaseList + testCaseMDList
 	endif
-	testCaseList = SortTestCaseList(procWin, testCaseList)
 
-	return CheckFunctionSignaturesTC(testCaseList, procWin)
+	return SortTestCaseList(procWin, testCaseList)
 End
 
 /// Returns the list of testcases sorted by line number
@@ -1677,6 +1676,8 @@ static Function/S getTestCasesMatch(procWinList, matchStr, enableRegExp, tcCount
 				endif
 				testCaseMatch = testCase
 			endif
+
+			testCaseMatch = CheckFunctionSignaturesTC(testCaseMatch, procWin)
 
 			numFL = ItemsInList(testCaseMatch)
 			numMatches += numFL


### PR DESCRIPTION
Before Function signatures were checked for all found TC unfiltered candidates,
that posed a potential problem if another TC was invalid. Causing an abort,
that prevented execution of the chosen test case.

close https://github.com/byte-physics/igor-unit-testing-framework/issues/105