### PR TITLE
Docu: Moved NULL_WAVE flag to Major flags for wave comparison

### DIFF
--- a/docu/sphinx/source/flags.rst
+++ b/docu/sphinx/source/flags.rst
@@ -27,14 +27,6 @@ Test Wave Flags
 The following flags are used in :cpp:func:`CHECK_WAVE`. Note that there is a
 minor and a major wave type.
 
-.. _flags_testwave_general:
-
-General
-"""""""
-
-.. doxygengroup:: TestWaveFlagsGeneral
-   :content-only:
-
 .. _flags_testwave_major:
 
 MajorType

--- a/procedures/unit-testing-constants.ipf
+++ b/procedures/unit-testing-constants.ipf
@@ -39,11 +39,6 @@ Constant REQUIRE_MODE   = 0x07 // == OUTPUT_MESSAGE | INCREASE_ERROR | ABORT_FUN
 /// @addtogroup assertionFlags
 ///@{
 
-/// @addtogroup testWaveFlagsGeneral
-///@{
-Constant NULL_WAVE       = 0x1000
-///@}
-
 /// @addtogroup testWaveFlagsMinor
 ///@{
 Constant COMPLEX_WAVE    = 0x01
@@ -58,6 +53,7 @@ Constant UNSIGNED_WAVE   = 0x40
 
 /// @addtogroup testWaveFlagsMajor
 ///@{
+Constant NULL_WAVE       = 0x1000
 Constant NUMERIC_WAVE    = 0x01
 Constant TEXT_WAVE       = 0x02
 Constant DATAFOLDER_WAVE = 0x04


### PR DESCRIPTION
NULL_WAVE was previously in the general flags section that was correct,
but also confusing. This change removes it from the docu for Minor flags,
which is ok, as testing for null waves through major and minor flags at
the same time is a non practical use case.

close https://github.com/byte-physics/igor-unit-testing-framework/issues/37