### PR TITLE
EQUAL_WAVE_WRAPPER: Make error reporting for custom mode patterns better

### DIFF
--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -668,8 +668,10 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 		return NaN
 	endif
 
+	Make/FREE validModes = { WAVE_DATA, WAVE_DATA_TYPE, WAVE_SCALING, DATA_UNITS, DIMENSION_UNITS, DIMENSION_LABELS, WAVE_NOTE, WAVE_LOCK_STATE, DATA_FULL_SCALE, DIMENSION_SIZES}
+
 	if(ParamIsDefault(mode))
-		Make/I/FREE modes = { WAVE_DATA, WAVE_DATA_TYPE, WAVE_SCALING, DATA_UNITS, DIMENSION_UNITS, DIMENSION_LABELS, WAVE_NOTE, WAVE_LOCK_STATE, DATA_FULL_SCALE, DIMENSION_SIZES}
+		WAVE modes = validModes
 	else
 		if(!UTF_Utils#IsFinite(mode))
 			EvaluateResults(0, "Valid mode for EQUAL_WAVE check.", flags)
@@ -679,7 +681,16 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 			return NaN
 		endif
 
-		Make/I/FREE modes = { mode }
+		// mode can be a bit pattern, split into separate entities for better debugging
+		Duplicate/FREE validModes, modes
+
+		modes[] = (validModes[p] == (validModes[p] & mode)) ? validModes[p] : NaN
+		WaveTransform/O zapNaNs modes
+
+		if(!DimSize(modes, 0))
+			EvaluateResults(0, "Valid mode for EQUAL_WAVE check.", flags)
+			return NaN
+		endif
 	endif
 
 	if(ParamIsDefault(tol))


### PR DESCRIPTION
The following test case

Function TestMe()

	Make/FREE data1
	Make/FREE/D data2

	CHECK_EQUAL_WAVES(data1, data2, mode = WAVE_DATA | WAVE_DATA_TYPE)
End

does currently produce the following output:

  Start of test "Unnamed"
  Entering test suite "Procedure"
  Entering test case "TestMe"
  Assuming equality using mode unknown mode for waves _free_ and _free_: is false. Assertion "CHECK_EQUAL_WAVES(data1, data2, mode = WAVE_DATA | WAVE_DATA_TYPE)" failed in line 11, procedure "Procedure"
  Leaving test case "TestMe"
  Failed with 1 errors
  Leaving test suite "Procedure"
  Test finished with 1 errors
  End of test "Unnamed"

The reported mode is "unknown" so this is puzzling already. It is also
not clear which mode check failed.

By splitting up each available mode bit into one entry in the modes wave
we gain better error reporting. A slight drawback is that we now have to
call EqualWaves multiple times.

The new output is:

  Start of test "Unnamed"
  Entering test suite "Procedure"
  Entering test case "TestMe"
  Assuming equality using mode WAVE_DATA_TYPE for waves _free_ and _free_: is false. Assertion "CHECK_EQUAL_WAVES(data1, data2, mode = WAVE_DATA | WAVE_DATA_TYPE)" failed in line 11, procedure "Procedure"
  Leaving test case "TestMe"
  Failed with 1 errors
  Leaving test suite "Procedure"
  Test finished with 1 errors
  End of test "Unnamed"

@MichaelHuth Please review.