### PR TITLE
.gitlab-ci.yml: Fix the paths for the documentation CI check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,11 +20,13 @@ documentation:
     - cp -r xml ../sphinx/source
     - cd ../sphinx
     - make html
+    - cd ../..
     - DOXYGEN_LOG=docu/doxygen/doxygen.log
     - if [[ -s ${DOXYGEN_LOG} ]]; then cat ${DOXYGEN_LOG}; exit 1; fi
     - SPHINX_LOG=docu/sphinx/sphinx.log
     - if [[ -s ${SPHINX_LOG} ]]; then cat ${SPHINX_LOG}; exit 1; fi
   artifacts:
+    when: always
     paths:
       - docu/sphinx/build/html
       - docu/doxygen/doxygen.log


### PR DESCRIPTION
Incorrectly implemented in 77f099dd (.gitlab-ci.yml: Make warning documentation a CI requirement, 2021-03-19).