### PR TITLE
AnalyzeTracingResult: Add missing \r on printf statement

### DIFF
--- a/procedures/unit-testing-tracing.ipf
+++ b/procedures/unit-testing-tracing.ipf
@@ -846,7 +846,7 @@ static Function AnalyzeTracingResult()
 		fName = procWin[0, strlen(procWin) - 5] + ".htm"
 		SaveNotebook/O/P=home/S=5/H={"UTF-8", 0xFFFF, 0xFFFF, 0, 0, 32} NBTracedData as fName
 	endfor
-	printf "Done."
+	printf "Done.\r"
 End
 
 #endif


### PR DESCRIPTION
Bug introduced in de9e739c (Multiple changes and fixes, 2021-07-15).