### PR TITLE
RunTest: Allow passing an empty traceWinList

### DIFF
--- a/docu/sphinx/source/advanced.rst
+++ b/docu/sphinx/source/advanced.rst
@@ -390,7 +390,7 @@ When running Igor Pro 9 or newer the Igor Unit testing Framework offers the feat
 information. When enabled the IUTF adds to functions in target procedure files code to track execution.
 At the end of the test run the IUTF outputs files in HTML format with coverage information.
 
-This feature is enabled when the optional parameter ``traceWinList`` is set when calling ``RunTest``.
+This feature is enabled when the optional parameter ``traceWinList`` is set and non-empty when calling ``RunTest``.
 Before the actual tests are executed the given procedure files are modified on disk where additional function calls are inserted.
 The additional code does not change the execution of the original code. This step is named ``Instrumentation``.
 The coverage results are output as HTML files in the experiments folder for each procedure file in the form:

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -2793,7 +2793,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 		s.debugMode = ParamIsDefault(debugMode) ? 0 : debugMode
 		s.keepDataFolder = ParamIsDefault(keepDataFolder) ? 0 : !!keepDataFolder
 
-		s.tracingEnabled = !ParamIsDefault(traceWinList)
+		s.tracingEnabled = !ParamIsDefault(traceWinList) && !UTF_Utils#IsEmpty(traceWinList)
 
 		if(s.enableTAP && s.juProps.enableJU)
 			sprintf msg, "Error: enableTAP and enableJU can not be both true."


### PR DESCRIPTION
We currently always do instrumentation as soon as the optional
traceWinList parameter is set.

But that is not nice for generic code calling us as that means it has to
branch out.

Accept an empty traceWinList string meaning the same as it being not
present.