### PR TITLE
Fix for stdout output of status messages length for IP9

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -1426,11 +1426,11 @@ static Function UTF_PrintStatusMessage(msg)
 	print/LEN=400 msg
 #endif
 
-#if (IgorVersion() >= 8.0)
+#if	(IgorVersion() >= 9.0)
+	fprintf -1, "%s\r\n", msg
+#elif (IgorVersion() >= 8.0)
 	tmpStr = UTF_Utils#PrepareStringForOut(msg, maxLen = IP8_PRINTF_STR_MAX_LENGTH - 2)
 	fprintf -1, "%s\r\n", tmpStr
-#elif	(IgorVersion() >= 9.0)
-	fprintf -1, "%s\r\n", msg
 #endif
 End
 


### PR DESCRIPTION
Due to a wrongly ordered ifdef check for the running IP version the console
output of status messages was for IP9 cut short to the maximum allowed length
of IP8. This was no critical issue but unecessary as IP9 supports full length
strings through fprintf.
The order was fixed and now with IP9 full length status messages are outout to
stdout.