### PR TITLE
Added preprocessor endif and else to be counted after the line of appearance

### DIFF
--- a/procedures/unit-testing-tracing.ipf
+++ b/procedures/unit-testing-tracing.ipf
@@ -325,6 +325,8 @@ static Function [WAVE/T w, string funcPath_, WAVE lineMark] AddTraceFunctions(st
 	"endswitch;", \
 	"endswitch", \
 	"endif", \
+	"#endif", \
+	"#else", \
 	"else" \
 	}
 	Make/FREE/T lineStartZReplaceKeys = { \

--- a/tests/test-tracing_instrumented.ipf
+++ b/tests/test-tracing_instrumented.ipf
@@ -98,12 +98,12 @@ Z_(0, 77)
 #if IgorVersion() < 9
 Z_(0, 78)
 	print "not nine"
-Z_(0, 79)
 #else
+Z_(0, 79)
 Z_(0, 80)
 	print "nine"
-Z_(0, 81)
 #endif
+Z_(0, 81)
 End
 // After Function 7
 


### PR DESCRIPTION
The preprocessor endif and else were handled like regular code lines where
counting is done after the line executed. To be in line with the normal
if else endif behavior it was changed.
This applies only to conditionals inside functions.
No conditional replacement of the preprocessor if is possible as calling Z_
requires compiled state.

close https://github.com/byte-physics/igor-unit-testing-framework/issues/235