### PR TITLE
Removed disabled attribute  the junit.xml example file in the documentation

### DIFF
--- a/docu/sphinx/source/junit.xml
+++ b/docu/sphinx/source/junit.xml
@@ -18,7 +18,6 @@
   <testsuite name=""      <!-- Full (class) name of the test for non-aggregated testsuite documents.
                                Class name without the package for aggregated testsuites documents. Required -->
 	     tests=""     <!-- The total number of tests in the suite, required. -->
-	     disabled=""  <!-- the total number of disabled tests in the suite. optional. not supported by maven surefire. -->
              errors=""    <!-- The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem,
                                for example an unchecked throwable; or a problem with the implementation of the test. optional -->
              failures=""  <!-- The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed


### PR DESCRIPTION
The original junit.xml file from https://llg.cubic.org/docs/junit/ included the
optional testsuite attribute "disabled". This attribute is not included in the
junit.xsd schema file.
For consistency the optional attribute is also removed in the example xml file.

close https://github.com/byte-physics/igor-unit-testing-framework/issues/244