### PR TITLE
Fix: Tracing must parse function decl types case-insensitive

### DIFF
--- a/procedures/unit-testing-tracing.ipf
+++ b/procedures/unit-testing-tracing.ipf
@@ -675,7 +675,7 @@ static Function CheckDeclarationLine(string line, WAVE/T decList)
 	type = StringFromList(0, line, " ")
 
 	for(i = 0; i < numParams; i += 1)
-		if(strsearch(type, validParameters[i], 0) >= 0)
+		if(strsearch(type, validParameters[i], 0, 2) >= 0)
 			foundType = 1
 			break
 		endif


### PR DESCRIPTION
Tracing parsed the function declaration types case-sensitive
Thus, for declaration if "variable" declaration is written as "Variable"
then the attribution of lines to the declaration block is aborted early.

since de9e739cd0492ddd2432c01a53a658767494197e