### PR TITLE
Revise IUTF setup step

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -1814,8 +1814,11 @@ End
 /// Function determines the total number of test cases
 /// Normal test cases are counted with 1
 /// MD test cases are counted by multiplying all data generator wave sizes
+/// When the optional string procWin is given then the number of test cases for that
+/// procedure window (test suite) is returned.
 /// Returns the total number of all test cases to be called
-static Function GetTestCaseCount()
+static Function GetTestCaseCount([procWin])
+	string procWin
 
 	variable i, j, size, dgenSize
 	variable tcCount, dgenCount
@@ -1825,6 +1828,10 @@ static Function GetTestCaseCount()
 	WAVE/T testRunData = GetTestRunData()
 	size = DimSize(testRunData, UTF_ROW)
 	for(i = 0; i < size; i += 1)
+		if(!ParamIsDefault(procWin) && CmpStr(procWin, testRunData[i][%PROCWIN]))
+			continue
+		endif
+
 		dgenCount = 1
 		dgenList = testRunData[i][%DGENLIST]
 		dgenSize = ItemsInList(dgenList)
@@ -3052,8 +3059,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 			getLocalHooks(s.procHooks, procWin)
 
 			if(startNextTS)
-				// TODO need tcCount for procWin
-				s.juProps.testCaseCount = s.tcCount
+				s.juProps.testCaseCount = GetTestCaseCount(procWin=procWin)
 				ExecuteHooks(TEST_SUITE_BEGIN_CONST, s.procHooks, s.juProps, procWin, procWin)
 				s.juProps.testSuiteNumber += 1
 			endif

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -74,6 +74,65 @@ static StrConstant BACKGROUNDMONTASK   = "UTFBackgroundMonitor"
 static StrConstant BACKGROUNDMONFUNC   = "UTFBackgroundMonitor"
 static StrConstant BACKGROUNDINFOSTR   = ":UNUSED_FOR_REENTRY:"
 static Constant IP8_PRINTF_STR_MAX_LENGTH = 2400
+static Constant WAVECHUNK_SIZE = 1024
+
+/// @brief Returns a global wave that stores data about this testrun
+static Function/WAVE GetTestRunData()
+
+	string name = "TestRunData"
+
+	DFREF dfr = GetPackageFolder()
+	WAVE/Z/T wv = dfr:$name
+	if(WaveExists(wv))
+		return wv
+	endif
+
+	Make/T/N=(0, 6) dfr:$name/WAVE=wv
+
+	SetDimLabel UTF_COLUMN, 0, PROCWIN, wv
+	SetDimLabel UTF_COLUMN, 1, TESTCASE, wv
+	SetDimLabel UTF_COLUMN, 2, FULLFUNCNAME, wv
+	SetDimLabel UTF_COLUMN, 3, DGENLIST, wv
+	SetDimLabel UTF_COLUMN, 4, TAP_SKIP, wv
+	SetDimLabel UTF_COLUMN, 5, EXPECTFAIL, wv
+
+	return wv
+End
+
+/// @brief Returns a global wave that stores the results of the DataGenerators of this testrun
+static Function/WAVE GetDataGeneratorWaves()
+
+	string name = "DataGeneratorWaves"
+
+	DFREF dfr = GetPackageFolder()
+	WAVE/Z/WAVE wv = dfr:$name
+	if(WaveExists(wv))
+		return wv
+	endif
+
+	Make/WAVE/N=0 dfr:$name/WAVE=wv
+
+	return wv
+End
+
+/// @brief Simple function to automatically increase the wave size by a chunk in the rows dimension
+///        The actual (filled) wave size is not tracked, the caller has to do that.
+///        Returns 1 if the wave was resized, 0 if it was not resized
+static Function EnsureLargeEnoughWaveSimple(wv, indexShouldExist)
+
+	WAVE wv
+	variable indexShouldExist
+
+	variable size = DimSize(wv, UTF_ROW)
+
+	if(indexShouldExist < size)
+		return 0
+	endif
+
+	Redimension/N=(size + WAVECHUNK_SIZE, -1, -1, -1) wv
+
+	return 1
+End
 
 /// @brief Helper function for try/catch with AbortOnRTE
 ///

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -2217,14 +2217,6 @@ static Function SaveState(dfr, s)
 	variable/G dfr:SenableTAP = s.enableTAP
 	variable/G dfr:SenableRegExp = s.enableRegExp
 	variable/G dfr:SkeepDataFolder = s.keepDataFolder
-	variable/G dfr:StcCount = s.tcCount
-
-	string/G dfr:SprocWin = s.procWin
-	string/G dfr:StestCaseList = s.testCaseList
-	string/G dfr:SallTestCasesList = s.allTestCasesList
-	string/G dfr:SfullFuncName = s.fullFuncName
-	variable/G dfr:Stap_skipCase = s.tap_skipCase
-	variable/G dfr:Stap_caseCount = s.tap_caseCount
 	variable/G dfr:SenableRegExpTC = s.enableRegExpTC
 	variable/G dfr:SenableRegExpTS = s.enableRegExpTS
 	variable/G dfr:SdgenIndex = s.dgenIndex
@@ -2233,10 +2225,8 @@ static Function SaveState(dfr, s)
 	variable/G dfr:StracingEnabled = s.tracingEnabled
 	variable/G dfr:ShtmlCreation = s.htmlCreation
 	string/G dfr:StcSuffix = s.tcSuffix
-	string/G dfr:SdgenFuncName = s.dgenFuncName
 
 	variable/G dfr:Si = s.i
-	variable/G dfr:Sj = s.j
 	variable/G dfr:Serr = s.err
 	StoreHooks(dfr, s.hooks, "TH")
 	StoreHooks(dfr, s.procHooks, "PH")
@@ -2299,20 +2289,6 @@ static Function RestoreState(dfr, s)
 	s.enableRegExp = var
 	NVAR var = dfr:SkeepDataFolder
 	s.keepDataFolder = var
-	NVAR var = dfr:StcCount
-	s.tcCount = var
-	SVAR str = dfr:SprocWin
-	s.procWin = str
-	SVAR str = dfr:StestCaseList
-	s.testCaseList = str
-	SVAR str = dfr:SallTestCasesList
-	s.allTestCasesList = str
-	SVAR str = dfr:SfullFuncName
-	s.fullFuncName = str
-	NVAR var = dfr:Stap_skipCase
-	s.tap_skipCase = var
-	NVAR var = dfr:Stap_caseCount
-	s.tap_caseCount = var
 	NVAR var = dfr:SenableRegExpTC
 	s.enableRegExpTC = var
 	NVAR var = dfr:SenableRegExpTS
@@ -2330,13 +2306,9 @@ static Function RestoreState(dfr, s)
 	s.htmlCreation = var
 	SVAR str = dfr:StcSuffix
 	s.tcSuffix = str
-	SVAR str = dfr:SdgenFuncName
-	s.dgenFuncName = str
 
 	NVAR var = dfr:Si
 	s.i = var
-	NVAR var = dfr:Sj
-	s.j = var
 	NVAR var = dfr:Serr
 	s.err = var
 
@@ -2584,13 +2556,7 @@ static Function InitStrRunTest(s)
 	s.name = ""
 	s.testCase = ""
 
-	s.procWin = ""
-	s.testCaseList = ""
-	s.allTestCasesList = ""
-	s.fullFuncName = ""
 	s.tcSuffix = ""
-	s.dgenFuncName = ""
-	s.tcCount = 0
 
 	InitJUProp(s.juProps)
 	InitHooks(s.hooks)
@@ -2607,14 +2573,6 @@ static Structure strRunTest
 	variable enableRegExp
 	variable debugMode
 	variable keepDataFolder
-	variable tcCount
-
-	string procWin
-	string testCaseList
-	string allTestCasesList
-	string fullFuncName
-	variable tap_skipCase
-	variable tap_caseCount
 	variable enableRegExpTC
 	variable enableRegExpTS
 	variable dgenIndex
@@ -2623,12 +2581,10 @@ static Structure strRunTest
 	variable tracingEnabled
 	variable htmlCreation
 	string tcSuffix
-	string dgenFuncName
 	STRUCT JU_Props juProps
 	STRUCT TestHooks hooks
 	STRUCT TestHooks procHooks
 	variable i
-	variable j
 	variable err
 EndStructure
 
@@ -2845,7 +2801,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 	variable reentry
 	// these use a very local scope where used
 	// loop counter and loop end derived vars
-	variable i, tcFuncCount, startNextTS, tap_skipCase
+	variable i, tcFuncCount, startNextTS, tap_skipCase, tcCount
 	string procWin, fullFuncName, previousProcWin, dgenFuncName
 	// used as temporal locals
 	variable var, err
@@ -2972,7 +2928,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 		endif
 
 		err = CreateTestRunSetup(s.procWinList, s.testCase, s.enableRegExpTC, errMsg)
-		s.tcCount = GetTestCaseCount()
+		tcCount = GetTestCaseCount()
 
 		if(err != TC_MATCH_OK)
 			if(err == TC_LIST_EMPTY)
@@ -3007,7 +2963,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 				ExecuteHooks(TEST_END_CONST, s.hooks, s.juProps, s.name, NO_SOURCE_PROCEDURE, param=s.debugMode)
 				Abort
 			else
-				TAP_WriteOutputIfReq("1.." + num2str(s.tcCount))
+				TAP_WriteOutputIfReq("1.." + num2str(tcCount))
 			endif
 		endif
 

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -702,11 +702,10 @@ Function IsExpectedFailure()
 	endif
 End
 
-/// Sets the expected_failure_flag according to if a test case is defined as expected failure
-static Function InitExpectedFailure(testCase)
-	string testCase
+/// Sets the expected_failure_flag global
+static Function SetExpectedFailure(val)
+	variable val
 
-	variable err
 	DFREF dfr = GetPackageFolder()
 	NVAR/Z/SDFR=dfr expected_failure_flag
 
@@ -715,7 +714,7 @@ static Function InitExpectedFailure(testCase)
 		NVAR/SDFR=dfr expected_failure_flag
 	endif
 
-	expected_failure_flag = UTF_Utils#HasFunctionTag(testCase, UTF_FTAG_EXPECTED_FAILURE)
+	expected_failure_flag = val
 End
 
 /// Return true if running in `ProcGlobal`, false otherwise
@@ -1399,7 +1398,6 @@ static Function TestCaseBegin(testCase)
 
 	initAssertCount()
 	initMessageBuffer()
-	InitExpectedFailure(StringFromList(0, testCase, ":"))
 
 	// create a new unique folder as working folder
 	dfref dfr = GetPackageFolder()
@@ -3014,6 +3012,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 				s.juProps.testSuiteNumber += 1
 			endif
 
+			SetExpectedFailure(str2num(testRunData[i][%EXPECTFAIL]))
 			// get Description and Directive of current Function for TAP
 			tap_skipCase = str2num(testRunData[i][%TAP_SKIP])
 			s.dgenIndex = 0

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -2845,14 +2845,8 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 	variable reentry
 	// these use a very local scope where used
 	// loop counter and loop end derived vars
-	variable i, tcFuncCount, startNextTS
-<<<<<<< HEAD
-	string procWin, fullFuncName, previousProcWin
-||||||| parent of a6297a8 (Retrieve Data Generator for TC from Setup Wave)
-	string procWin, fullFuncName
-=======
-	string procWin, fullFuncName, dgenFuncName
->>>>>>> a6297a8 (Retrieve Data Generator for TC from Setup Wave)
+	variable i, tcFuncCount, startNextTS, tap_skipCase
+	string procWin, fullFuncName, previousProcWin, dgenFuncName
 	// used as temporal locals
 	variable var
 	string msg, str
@@ -3065,10 +3059,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 			endif
 
 			// get Description and Directive of current Function for TAP
-			s.tap_skipCase = 0
-			if(TAP_IsOutputEnabled())
-				s.tap_skipCase = TAP_IsFunctionSkip(fullFuncName)
-			endif
+			tap_skipCase = str2num(testRunData[i][%TAP_SKIP])
 			s.dgenIndex = 0
 			s.tcSuffix = ""
 		endif
@@ -3090,22 +3081,25 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 						s.tcSuffix = ":" + num2istr(s.dgenIndex)
 					endif
 				endif
-				if(!s.tap_skipCase)
+				if(!tap_skipCase)
 					ExecuteHooks(TEST_CASE_BEGIN_CONST, s.procHooks, s.juProps, fullFuncName + s.tcSuffix, procWin)
 				endif
 			else
 
 				DFREF dfSave = $PKG_FOLDER_SAVE
 				RestoreState(dfSave, s)
-				// restore all loop counters and end loop locals
-				i = s.i
 				// restore state done
 				DFREF dfSave = $""
 				ClearReentrytoUTF()
+				// restore all loop counters and end loop locals
+				i = s.i
+				procWin = testRunData[i][%PROCWIN]
+				fullFuncName = testRunData[i][%FULLFUNCNAME]
+				tap_skipCase = str2num(testRunData[i][%TAP_SKIP])
 
 			endif
 
-			if(!s.tap_skipCase)
+			if(!tap_skipCase)
 
 				try
 					ClearRTError()
@@ -3144,7 +3138,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 				return RUNTEST_RET_BCKG
 			endif
 
-			if(!s.tap_skipCase)
+			if(!tap_skipCase)
 				ExecuteHooks(TEST_CASE_END_CONST, s.procHooks, s.juProps, fullFuncName + s.tcSuffix, procWin, param = s.keepDataFolder)
 			endif
 
@@ -3152,7 +3146,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 				break
 			endif
 
-			TAP_WriteCaseIfReq(s.i + 1, s.tap_skipCase)
+			TAP_WriteCaseIfReq(s.i + 1, tap_skipCase)
 
 			s.dgenIndex += 1
 

--- a/procedures/unit-testing-tap.ipf
+++ b/procedures/unit-testing-tap.ipf
@@ -106,20 +106,15 @@ End
 ///
 /// @param testCaseList list of function names
 /// @returns 1 if all test cases are marked as SKIP and TAP is enabled, zero otherwise
-Function TAP_AreAllFunctionsSkip(testCaseList)
-	string testCaseList
+Function TAP_AreAllFunctionsSkip()
 
-	string funcName
-	variable i, numItems
+	variable dimPos
 
-	numItems = ItemsInList(testCaseList)
-	for(i = 0; i < numItems; i += 1)
-		funcName = StringFromList(i, testCaseList)
-		if(!TAP_IsFunctionSkip(funcName))
-			return 0
-		endif
-	endfor
-	return 1
+	WAVE/T testRunData = UTF_Basics#GetTestRunData()
+	dimPos = FindDimLabel(testRunData, UTF_COLUMN, "TAP_SKIP")
+	Duplicate/FREE/R=[][dimPos, dimPos] testRunData, skipCol
+
+	return DimSize(testRunData, UTF_ROW) == sum(skipCol)
 End
 
 /// @brief returns 1 if function is marked as TODO, zero otherwise

--- a/procedures/unit-testing-tap.ipf
+++ b/procedures/unit-testing-tap.ipf
@@ -165,7 +165,7 @@ Function TAP_IsFunctionSkip(funcName)
 	string str
 
 	str = UTF_Utils#GetFunctionTagValue(funcName, UTF_FTAG_TAP_DIRECTIVE, err)
-	if(!err)
+	if(err == UTF_TAG_OK)
 		return strsearch(str, "SKIP", 0, 2) == 0
 	endif
 

--- a/procedures/unit-testing-tracing.ipf
+++ b/procedures/unit-testing-tracing.ipf
@@ -393,7 +393,8 @@ static Function [WAVE/T w, string funcPath_, WAVE lineMark] AddTraceFunctions(st
 	WAVE macroLineStarts = FindMacroLocations(wMacroList)
 	Make/FREE/WAVE/N=(numMacros) macroTexts
 	macroTexts[] = ListToTextWave(ProcedureText(wMacroList[p], 0, procWin), "\r")
-	Make/FREE/D/N=(numMacros) macroExclusionFlag
+	Make/FREE/D/N=(numMacros) macroExclusionFlag, macroIndexHelper
+	macroIndexHelper[] = UTF_Basics#AddFunctionTagWave(wMacroList[p])
 	macroExclusionFlag[] = UTF_Utils#HasFunctionTag(wMacroList[p], UTF_FTAG_NOINSTRUMENTATION)
 	for(i = 0; i < numMacros; i += 1)
 		if(UTF_Utils#isEmpty(procedurePath))
@@ -415,6 +416,7 @@ static Function [WAVE/T w, string funcPath_, WAVE lineMark] AddTraceFunctions(st
 			printf "Is procedure file %s missing a #pragma ModuleName=<name> ?!?.\r", procWin
 			continue
 		endif
+		UTF_Basics#AddFunctionTagWave(fullFuncName)
 		funcExclusionFlag[i] = UTF_Utils#HasFunctionTag(fullFuncName, UTF_FTAG_NOINSTRUMENTATION)
 		if(UTF_Utils#isEmpty(procedurePath))
 			procedurePath = FunctionPath(fullFuncName)

--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -156,7 +156,15 @@ End
 static Function HasFunctionTag(funcName, tagName)
 	string funcName, tagName
 
-	WAVE tagValues = GetFunctionTagWave(funcName)
+	variable funcPos
+
+	WAVE/WAVE ftagWaves = UTF_Basics#GetFunctionTagWaves()
+	funcPos = FindDimLabel(ftagWaves, UTF_ROW, funcName)
+	if(funcPos == -2)
+		return 0
+	endif
+
+	WAVE tagValues = ftagWaves[funcPos]
 
 	return (FindDimLabel(tagValues, UTF_ROW, tagName) != -2)
 End
@@ -168,16 +176,23 @@ End
 /// @param[in]  tagName  tag that is searched (see UTF_UTILS#FunctionTagStrings for possible tags)
 /// @param[out] err      error code (see constants UTF_UTILS#TAG*)
 /// @returns             value belonging to a certain tag in the comments above a function, error message if not found
-static Function/T GetFunctionTagValue(funcName, tagName, err)
+static Function/S GetFunctionTagValue(funcName, tagName, err)
 	string funcName, tagName
 	variable &err
 
-	variable tagPosition
+	variable tagPosition, funcPos
 	string tagValue, msg
 
 	err = UTF_TAG_ABORTED
-	WAVE/T tagValueWave = GetFunctionTagWave(funcName)
+	WAVE/WAVE ftagWaves = UTF_Basics#GetFunctionTagWaves()
+	funcPos = FindDimlabel(ftagWaves, UTF_ROW, funcName)
+	if(funcPos == -2)
+		err = UTF_TAG_NOT_FOUND
+		sprintf msg, "The tag %s was not found.", tagName
+		return msg
+	endif
 
+	WAVE/T tagValueWave = ftagWaves[funcPos]
 	tagPosition = FindDimLabel(tagValueWave, UTF_ROW, tagName)
 	if(tagPosition == -2)
 		err = UTF_TAG_NOT_FOUND
@@ -193,6 +208,7 @@ static Function/T GetFunctionTagValue(funcName, tagName, err)
 	endif
 
 	err = UTF_TAG_OK
+
 	return tagValue
 End
 

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -619,17 +619,56 @@ static Function TestUTF()
 
 	// @}
 
+End
+
+static Function/WAVE GeneratorSC()
+
+	Make/FREE/N=10 data
+
+	NVAR/Z cc = root:dgenCallCount
+	if(!NVAR_Exists(cc))
+		variable/G root:dgenCallCount = 1
+	else
+		cc += 1
+	endif
+
+	return data
+End
+
+// UTF_TD_GENERATOR GeneratorSC
+static Function TestDGenSingleCall_A([var])
+	variable var
+
+	PASS()
+End
+
+static Function TestDGenSingleCall_B()
+
+	NVAR/Z cc = root:dgenCallCount
+	REQUIRE(NVAR_Exists(cc))
+	CHECK_EQUAL_VAR(cc, 1)
+End
+
+static Function TestIUTFSetup()
+
 	// TestCaseNameNotation
 	// @{
 
-	variable tmpVar1, tmpVar2
-	string thisProcName, tcList
+	variable tmpVar1
+	string thisProcName, tmpStr
 	thisProcName = ParseFilePath(0, FunctionPath("TestCaseNameTest2"), ":", 1, 0)
-	tcList = UTF_Basics#getTestCasesMatch(thisProcName, ".*", 1, tmpVar1, tmpVar2)
-	Ensure(WhichListItem("UTF_Tests#TestCaseNameTest1", tcList) >= 0)
-	Ensure(WhichListItem("TestCaseNameTest2", tcList) >= 0)
+	Ensure(UTF_Basics#CreateTestRunSetup(thisProcName, ".*", 1, tmpStr) == 0)
+	WAVE/T testRunData = UTF_Basics#GetTestRunData()
+	tmpVar1 = FindDimLabel(testRunData, UTF_COLUMN, "TESTCASE")
+	Duplicate/FREE/R=[][tmpVar1, tmpVar1] testRunData, tcCol
+	FindValue/TXOP=4/TEXT="UTF_Tests#TestCaseNameTest1" tcCol
+	Ensure(V_value >= 0)
+	FindValue/TXOP=4/TEXT="TestCaseNameTest2" tcCol
+	Ensure(V_value >= 0)
 
 	// @}
+
+	PASS()
 End
 
 static Function TestCaseNameTest1()
@@ -641,3 +680,12 @@ Function TestCaseNameTest2()
 
 	PASS()
 End
+
+#if IgorVersion() >= 7
+static Function TEST_SUITE_END_OVERRIDE(name)
+	string name
+
+	NVAR/Z cc = root:dgenCallCount
+	KillVariables/Z cc
+End
+#endif


### PR DESCRIPTION
Optimize code by setting up global waves that store most of the data per test case.
Also add global wave to store datagenerator waves and tag values of functions.

Change code to use these new global storages and discard the old obsolete ones.

close https://github.com/byte-physics/igor-unit-testing-framework/issues/168