### PR TITLE
RunTest: Initialize at the earliest possible moment

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -3439,6 +3439,10 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 		endif
 
 	else
+		// no early return/abort above this point
+		ClearTestSetupWaves()
+		ClearBaseFilename()
+		CreateHistoryLog()
 
 		PathInfo home
 		if(!V_flag)
@@ -3527,11 +3531,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 #endif
 		endif
 
-		ClearTestSetupWaves()
-
 		// below here use only s. variables to keep local state in struct
-		ClearBaseFilename()
-		CreateHistoryLog()
 
 		s.procWinList = AdaptProcWinList(s.procWinList, s.enableRegExpTS)
 		s.procWinList = FindProcedures(s.procWinList, s.enableRegExpTS)


### PR DESCRIPTION
When running testing with instrumentation and the instrumented code errors out as the code is already instrumented we don't output any history log. This happens with all errors which happen earlier as the history log initialization.

So let's move the initialization to the earliest possible moment.