### PR TITLE
Fix #266. Test case hooks are evaluated as MD test cases in Igor Pro 6

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -1629,9 +1629,16 @@ static Function CheckFunctionSignatureTC(procWin, fullFuncName, dgenList, markSk
 
 	variable err, wType1, wType0, wRefSubType
 	string dgen, msg
+	string funcInfo
 
 	dgenList = ""
 	markSkip = 0
+
+	// Require only optional parameter
+	funcInfo = FunctionInfo(fullFuncName)
+	if (NumberByKey("N_PARAMS", funcInfo) != NumberByKey("N_OPT_PARAMS", funcInfo))
+		return 1
+	endif
 
 	// Simple Test Cases
 	FUNCREF TEST_CASE_PROTO fTC = $fullFuncName

--- a/tests/Various.ipf
+++ b/tests/Various.ipf
@@ -346,11 +346,9 @@ Function TC_MMD_bck_REENTRY([md])
 	PASS()
 End
 
-#if IgorVersion() >= 7
 static Function TEST_SUITE_END_OVERRIDE(name)
 	string name
 
 	NVAR/Z cc = root:dgenCallCount
 	KillVariables/Z cc
 End
-#endif


### PR DESCRIPTION
Every function is now checked to have only optional parameter. This will prevent hooks from used as testcases.

Close #266 .