### PR TITLE
Enhance Wave Printing

### DIFF
--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -329,21 +329,34 @@ static Function/S DetermineWaveDataDifference(wv1, wv2, tol)
 
 	string msg
 	variable isComplex1, isComplex2
-	string wvName1, wvName2
+	string wvId1, wvId2, wvName1, wvName2
 	string wvNamePrefix, tmpStr1, tmpStr2
 
 	// Generate names for reference
 	if(WaveExists(wv1))
-		wvName1 = GetWaveNameInDFStr(wv1)
+		wvId1 = GetWaveNameInDFStr(wv1)
+		wvName1 = NameOfWave(wv1)
 	else
+		wvId1 = "_null_"
 		wvName1 = "_null_"
 	endif
 	if(WaveExists(wv2))
-		wvName2 = GetWaveNameInDFStr(wv2)
+		wvId2 = GetWaveNameInDFStr(wv2)
+		wvName2 = NameOfWave(wv2)
 	else
+		wvId2 = "_null_"
 		wvName2 = "_null_"
 	endif
-	wvNamePrefix = "Wave1: " + wvName1 + "\rWave2: " + wvName2 + "\r"
+	if(strsearch(wvId1, " in ", 0) >= 0)
+		sprintf wvNamePrefix, "Wave1: %s\r", wvId1
+	else
+		sprintf wvNamePrefix, "Wave1: %s (%s)\r", wvName1, wvId1
+	endif
+	if(strsearch(wvId2, " in ", 0) >= 0)
+		sprintf wvNamePrefix, "%sWave2: %s\r", wvNamePrefix, wvId2
+	else
+		sprintf wvNamePrefix, "%sWave2: %s (%s)\r", wvNamePrefix, wvName2, wvId2
+	endif
 
 	// Size Check
 	Make/FREE/D wv1Dims = {DimSize(wv1, UTF_ROW), DimSize(wv1, UTF_COLUMN), DimSize(wv1, UTF_LAYER), DimSize(wv1, UTF_CHUNK)}

--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -407,7 +407,7 @@ static Function IterateOverWaves(table, wv1, wv2, rows, cols, layers, chunks, to
 			for(k = 0; k < layers; k += 1)
 				for(j = 0; j < cols; j += 1)
 					for(i = 0; i < rows; i += 1)
-						AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, runTol, tol)
+						AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, 4, runTol, tol)
 						if(locCount == UTF_MAXDIFFCOUNT)
 							return NaN
 						endif
@@ -419,7 +419,7 @@ static Function IterateOverWaves(table, wv1, wv2, rows, cols, layers, chunks, to
 		for(k = 0; k < layers; k += 1)
 			for(j = 0; j < cols; j += 1)
 				for(i = 0; i < rows; i += 1)
-					AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, runTol, tol)
+					AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, 3, runTol, tol)
 					if(locCount == UTF_MAXDIFFCOUNT)
 						return NaN
 					endif
@@ -429,7 +429,7 @@ static Function IterateOverWaves(table, wv1, wv2, rows, cols, layers, chunks, to
 	elseif(cols)
 		for(j = 0; j < cols; j += 1)
 			for(i = 0; i < rows; i += 1)
-				AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, runTol, tol)
+				AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, 2, runTol, tol)
 				if(locCount == UTF_MAXDIFFCOUNT)
 					return NaN
 				endif
@@ -437,7 +437,7 @@ static Function IterateOverWaves(table, wv1, wv2, rows, cols, layers, chunks, to
 		endfor
 	else
 		for(i = 0; i < rows; i += 1)
-			AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, runTol, tol)
+			AddValueDiffImpl(table, wv1, wv2, locCount, i, j, k, l, 1, runTol, tol)
 			if(locCount == UTF_MAXDIFFCOUNT)
 				return NaN
 			endif
@@ -630,11 +630,11 @@ static Function/S SPrintWaveElement(w, row, col, layer, chunk)
 	return str
 End
 
-static Function AddValueDiffImpl(table, wv1, wv2, locCount, row, col, layer, chunk, runTol, tol)
+static Function AddValueDiffImpl(table, wv1, wv2, locCount, row, col, layer, chunk, dimensions, runTol, tol)
 	WAVE/T table
 	WAVE wv1, wv2
 	variable &locCount
-	variable row, col, layer, chunk
+	variable row, col, layer, chunk, dimensions
 	variable &runTol
 	variable tol
 
@@ -770,7 +770,23 @@ static Function AddValueDiffImpl(table, wv1, wv2, locCount, row, col, layer, chu
 		endif
 	endif
 
-	sprintf str, "[%d][%d][%d][%d]", row, col, layer, chunk
+	switch (dimensions)
+		case 1:
+			sprintf str, "[%d]", row
+			break
+		case 2:
+			sprintf str, "[%d][%d]", row, col
+			break
+		case 3:
+			sprintf str, "[%d][%d][%d]", row, col, layer
+			break
+		case 4:
+			sprintf str, "[%d][%d][%d][%d]", row, col, layer, chunk
+			break
+		default:
+			Abort "Unsupported number of dimensions"
+			break
+	endswitch
 	table[2 * locCount][%DIMS] = str
 	Make/FREE/T wDL1 = {GetDimLabel(wv1, UTF_ROW, row), GetDimLabel(wv1, UTF_COLUMN, col), GetDimLabel(wv1, UTF_LAYER,layer), GetDimLabel(wv1, UTF_CHUNK, chunk)}
 	str = wDL1[0] + wDL1[1] + wDL1[2] + wDL1[3]

--- a/tests/Various.ipf
+++ b/tests/Various.ipf
@@ -346,6 +346,40 @@ Function TC_MMD_bck_REENTRY([md])
 	PASS()
 End
 
+Function TC_UTILS_GetNiceStringForNumber()
+	// no decimal point, short numbers
+	TC_UTILS_GNSFN_Check_IGNORE("2", "2", 2)
+
+	// small amount of digits behind decimal point
+	TC_UTILS_GNSFN_Check_IGNORE("3.14", "3.14", 3.14)
+
+	// medium amount of digits behind decimal point
+	TC_UTILS_GNSFN_Check_IGNORE("3.141593", "3.141593", 3.141593)
+
+	// big amount of digits behind decimal point
+	TC_UTILS_GNSFN_Check_IGNORE("3.141593", "3.141592653589793", 3.141592653589793)
+
+	// really large number
+	TC_UTILS_GNSFN_Check_IGNORE("1e+30", "1e+30", 1e30)
+	TC_UTILS_GNSFN_Check_IGNORE("3.141593e+07", "31415926.53589793", pi * 1e7)
+
+	// all checks passed
+	PASS()
+End
+
+Function TC_UTILS_GNSFN_Check_IGNORE(expect32, expect64, num)
+	string expect32, expect64
+	variable num
+
+	string str
+
+	str = UTF_UTILS#GetNiceStringForNumber(num, isDouble=0)
+	REQUIRE_EQUAL_STR(expect32, str)
+
+	str = UTF_UTILS#GetNiceStringForNumber(num, isDouble=1)
+	REQUIRE_EQUAL_STR(expect64, str)
+End
+
 static Function TEST_SUITE_END_OVERRIDE(name)
 	string name
 


### PR DESCRIPTION
What has been done:
- The names of the waves are always printed
- Only the index from used dimensions are printed. If a wave has only two dimensions so it will print only an index like `[3][1]` and not `[3][1][0][0]`.
- Trailing zeros after the decimal point for FP32 and FP64 waves are removed
- Trailing zeros after the decimal point for Complex FP32 and FP64 waves are removed
- all significant digits of the number are shown. A difference of the number should always be visible.

What has not been done:
- colored string diff. This is impossible to do with the current release of Igor Pro. String Diffing has not been changed.

Closing #221 .
