### PR TITLE
Redesign EQUAL_WAVE_WRAPPER for identical wave references

### DIFF
--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -630,6 +630,7 @@ End
 /// Tests two waves for equality.
 /// If one wave has a zero size and the other one does not then properties like DIMENSION_UNITS are compared to unequal as a property for a
 /// non-existing dimension is always unequal to a property of an existing dimension.
+/// This function won't throw an assert if both waves have the same reference, because they are considered as equal.
 ///
 /// @param wv1    first wave
 /// @param wv2    second wave
@@ -658,13 +659,6 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 
 	result = WaveExists(wv2)
 	EvaluateResults(result, "Assumption that the second wave (wv2) exists", flags)
-
-	if(!result)
-		return NaN
-	endif
-
-	result = !WaveRefsEqual(wv1, wv2)
-	EvaluateResults(result, "Assumption that both waves are distinct", flags)
 
 	if(!result)
 		return NaN

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -320,6 +320,8 @@ static Function TestUTF()
 	UTF_Wrapper#EQUAL_WAVE_WRAPPER($"", $"", !OUTPUT_MESSAGE)
 	UTF_Wrapper#EQUAL_WAVE_WRAPPER(numData1, $"", !OUTPUT_MESSAGE)
 	UTF_Wrapper#EQUAL_WAVE_WRAPPER($"", numData2, !OUTPUT_MESSAGE)
+	// equal waves
+	UTF_Wrapper#EQUAL_WAVE_WRAPPER(numData1, numData1, !OUTPUT_MESSAGE)
 	// different type zero sized waves
 	Make/FREE/N=0/D wNumType1
 	Make/FREE/N=0/I wNumType2


### PR DESCRIPTION
Enables CHECK_EQUAL_WAVES, WARN_EQUAL_WAVES and REQUIRE_EQUAL_WAVES to accept two identical wave references.

Before this change it will always return an error.

This bug was nowhere mentioned in documentation or test examples.

Close #49