### PR TITLE
Enable size only checks for different typed waves

### DIFF
--- a/procedures/unit-testing-assertion-checks.ipf
+++ b/procedures/unit-testing-assertion-checks.ipf
@@ -216,8 +216,15 @@ static Function AreWavesEqual(wv1, wv2, mode, tol, detailedMsg)
 	string dimLabelMsg = ""
 	variable result, err
 
-	if((!numpnts(wv1) || !numpnts(wv2)) && mode == WAVE_DATA)
-		result = !numpnts(wv1) && !numpnts(wv2)
+	if(mode == WAVE_DATA)
+		if(!numpnts(wv1) || !numpnts(wv2))
+			result = !numpnts(wv1) && !numpnts(wv2)
+		elseif(WaveType(wv1, 1) != WaveType(wv2, 1))
+			detailedMsg = "The base wave types are different, WAVE_DATA can not be compared."
+			return 0
+		else
+			result = EqualWaves(wv1, wv2, mode, tol) == 1
+		endif
 	else
 		result = EqualWaves(wv1, wv2, mode, tol) == 1
 	endif

--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -699,11 +699,6 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 		return NaN
 	endif
 
-	if((WaveType(wv1, 1) != WaveType(wv2, 1)) && !(!numpnts(wv1) && !numpnts(wv2)))
-		EvaluateResults(0, "Compatible basic wave type for EQUAL_WAVE check.", flags)
-		return NaN
-	endif
-
 	for(i = 0; i < DimSize(modes, 0); i += 1)
 		mode = modes[i]
 		result = UTF_Checks#AreWavesEqual(wv1, wv2, mode, tol, detailedMsg)

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -383,6 +383,32 @@ static Function TestUTF()
 	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvDP, DATA_FULL_SCALE, DEFAULT_TOLERANCE, detailedMsg))
 	Ensure(!UTF_Checks#AreWavesEqual(wvSP, wvDP, DIMENSION_SIZES, DEFAULT_TOLERANCE, detailedMsg))
 
+	Make/FREE/N=0 wvSP
+	Make/FREE/N=0/T wvTEXT
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, WAVE_DATA, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(!UTF_Checks#AreWavesEqual(wvSP, wvTEXT, WAVE_DATA_TYPE, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, WAVE_SCALING, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, DATA_UNITS, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, DIMENSION_UNITS, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, DIMENSION_LABELS, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, WAVE_NOTE, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, WAVE_LOCK_STATE, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, DATA_FULL_SCALE, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, DIMENSION_SIZES, DEFAULT_TOLERANCE, detailedMsg))
+
+	Make/FREE/N=(4,3,2,1) wvSP
+	Make/FREE/N=(4,3,2,1)/T wvTEXT
+	Ensure(!UTF_Checks#AreWavesEqual(wvSP, wvTEXT, WAVE_DATA, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(!UTF_Checks#AreWavesEqual(wvSP, wvTEXT, WAVE_DATA_TYPE, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, WAVE_SCALING, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, DATA_UNITS, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, DIMENSION_UNITS, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, DIMENSION_LABELS, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, WAVE_NOTE, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, WAVE_LOCK_STATE, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, DATA_FULL_SCALE, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(UTF_Checks#AreWavesEqual(wvSP, wvTEXT, DIMENSION_SIZES, DEFAULT_TOLERANCE, detailedMsg))
+
 	SetScale d, 1, 2, "dataUnitSP", wvSP
 	SetScale d, 3, 4, "dataUnitDP", wvDP
 	Note/K wvSP, "waveNoteSP"


### PR DESCRIPTION
Before checking any wave property the unit testing framework will always
check if the types are compatible. This can yield to unintended behavior
when for example only the sizes should be checked and the waves are
intended to be different typed.

With this change the type check is restructured to enforce same typed
waves only for WAVE_DATA checks.

Close #199.