### PR TITLE
unit-testing-junit.ipf: Improve accuracy of test case/suite durations

### DIFF
--- a/procedures/unit-testing-junit.ipf
+++ b/procedures/unit-testing-junit.ipf
@@ -377,7 +377,7 @@ Function JU_TestSuiteBegin(s, name, procWin)
 	s.juTS.timestamp = JU_GetISO8601TimeStamp()
 	s.juTS.hostname = "localhost"
 	s.juTS.tests = s.testCaseCount
-	s.juTS.timeStart = DateTime
+	s.juTS.timeStart = JU_GetRelativeTime()
 	s.juTS.failures = 0
 	s.juTS.errors = 0
 	s.juTS.skipped = 0
@@ -419,7 +419,7 @@ Function JU_TestCaseBegin(s, fullfuncName, procWin)
 
 	s.juTC.name = fullfuncName + " in " + procWin + " (" + num2str(run_count) + ")"
 	s.juTC.className = fullfuncName
-	s.juTC.timeStart = DateTime
+	s.juTC.timeStart = JU_GetRelativeTime()
 	s.juTC.error_count = error_count
 	Notebook HistoryCarbonCopy, getData = 1
 	s.juTC.history = S_Value
@@ -448,7 +448,7 @@ Function JU_TestCaseEnd(s, funcName, procWin, tcIndex)
 	NVAR/SDFR=dfr error_count
 	SVAR/SDFR=dfr systemErr
 
-	s.juTC.timeTaken = DateTime - s.juTC.timeStart
+	s.juTC.timeTaken = JU_GetRelativeTime() - s.juTC.timeStart
 	s.juTC.error_count = error_count - s.juTC.error_count
 	// disabled code 4 is currently not implemented
 	if(shouldDoAbort())
@@ -477,6 +477,11 @@ Function JU_TestSuiteEnd(s)
 		return NaN
 	endif
 
-	s.juTS.timeTaken = DateTime - s.juTS.timeStart
+	s.juTS.timeTaken = JU_GetRelativeTime() - s.juTS.timeStart
 	s.testSuiteOut += JU_CaseListToSuiteOut(s.testCaseListOut, s.juTS, s.juTSProp)
+End
+
+/// Return a relative timestamp [s] with microsecond precision
+static Function JU_GetRelativeTime()
+	return stopMSTimer(-2) / 1e6
 End


### PR DESCRIPTION
Ever since the introduction of JUNIT support in 7b71266a (Added JUNIT support, 2017-03-16) we have calculated the durations of a test case or test suite using DateTime.

The default choice for relative time tracking is usually stopmstimer(-2).

And this can also be verified using the following example:

print/D stopmstimer(-2)/1000, stopmstimer(-2)/1000, stopmstimer(-2)/1000, stopmstimer(-2)/1000, stopmstimer(-2)/1000
  11962615.9893  11962616.1171  11962616.2341  11962616.3487  11962616.4618
print/D datetime , datetime, datetime, datetime, datetime
  3749025804.137  3749025804.137  3749025804.137  3749025804.138  3749025804.138

Here the timestamps for stopmstimer vary with every call, but DateTime stays constant.

So let's use stopMSTimer(-2) for higher accuracy.

This can be verified executing the MIES [1] test case WorksWithSameWordAndRepl which now has an execution time of 0.006 s instead of 0.000 s.

[1]: https://github.com/AllenInstitute/MIES