### PR TITLE
Show wave names in diff temp wave output

### DIFF
--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -642,7 +642,7 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 	variable mode, tol
 
 	variable i, result
-	string str, detailedMsg
+	string str, detailedMsg, name1, name2
 
 	incrAssert()
 
@@ -708,7 +708,9 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 		mode = modes[i]
 		result = UTF_Checks#AreWavesEqual(wv1, wv2, mode, tol, detailedMsg)
 
-		sprintf str, "Assuming equality using mode %s for waves %s and %s", EqualWavesModeToString(mode), NameOfWave(wv1), NameOfWave(wv2)
+		name1 = UTF_Utils#GetWaveNameInDFStr(wv1)
+		name2 = UTF_Utils#GetWaveNameInDFStr(wv2)
+		sprintf str, "Assuming equality using mode %s for waves %s and %s", EqualWavesModeToString(mode), name1, name2
 
 		if(!UTF_Utils#IsEmpty(detailedMsg))
 			str += "; detailed: " + detailedMsg

--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -357,21 +357,13 @@ static Function/S DetermineWaveDataDifference(wv1, wv2, tol)
 
 	string msg
 	variable isComplex1, isComplex2
-	string wvName1, wvName2
+	string wvId1, wvId2
 	string wvNamePrefix, tmpStr1, tmpStr2
 
 	// Generate names for reference
-	if(WaveExists(wv1))
-		wvName1 = GetWaveNameInDFStr(wv1)
-	else
-		wvName1 = "_null_"
-	endif
-	if(WaveExists(wv2))
-		wvName2 = GetWaveNameInDFStr(wv2)
-	else
-		wvName2 = "_null_"
-	endif
-	wvNamePrefix = "Wave1: " + wvName1 + "\rWave2: " + wvName2 + "\r"
+	wvId1 = GetWaveNameInDFStr(wv1)
+	wvId2 = GetWaveNameInDFStr(wv2)
+	sprintf wvNamePrefix, "Wave1: %s\rWave2: %s\r", wvId1, wvId2
 
 	// Size Check
 	Make/FREE/D wv1Dims = {DimSize(wv1, UTF_ROW), DimSize(wv1, UTF_COLUMN), DimSize(wv1, UTF_LAYER), DimSize(wv1, UTF_CHUNK)}
@@ -516,15 +508,19 @@ threadsafe static Function/S GetWavePointer(wv)
 End
 
 static Function/S GetWaveNameInDFStr(w)
-	WAVE w
+	WAVE/Z w
 
 	string str
+
+	if(!WaveExists(w))
+		return "_null_"
+	endif
 
 	str = NameOfWave(w)
 	if(WaveType(w, 2) != IUTF_WAVETYPE2_FREE)
 		str += " in " + GetWavesDataFolder(w, 1)
 	else
-		str = GetWavePointer(w)
+		str += " (" + GetWavePointer(w) + ")"
 	endif
 
 	return str

--- a/tests/Various.ipf
+++ b/tests/Various.ipf
@@ -451,6 +451,32 @@ static Function TC_BreaksHard()
 	CHECK_EQUAL_WAVES(wv1, wv2)
 End
 
+static Function TC_WaveName()
+	string dfr, str, expect
+
+	dfr = GetDataFolder(1)
+
+	str = UTF_Utils#GetWaveNameInDFStr($"")
+	expect = "_null_"
+	CHECK_EQUAL_STR(expect, str)
+
+	Make namedDFWave
+	str = UTF_Utils#GetWaveNameInDFStr(namedDFWave)
+	expect = "namedDFWave in " + dfr
+	CHECK_EQUAL_STR(expect, str)
+
+	Make/FREE unnamedFreeWave
+	str = UTF_UTILS#GetWaveNameInDFStr(unnamedFreeWave)
+	CHECK(GrepString(str, "^_free_ \\(0x[0-9a-f]+\\)$"))
+
+#if IgorVersion() >= 9.0
+	Make/FREE=1 namedFreeWave
+	str = UTF_Utils#GetWaveNameInDFStr(namedFreeWave)
+	CHECK(GrepString(str, "^namedFreeWave \\(0x[0-9a-f]+\\)$"))
+#endif
+
+End
+
 static Function TEST_SUITE_END_OVERRIDE(name)
 	string name
 


### PR DESCRIPTION
Before there was only the reference for the temp waves listed like so:

Wave1: 0x084edf7ad0
Wave2: 0x084edf76b0

This commit add the wave names to this listing:

Wave1: wv1 (0x084edf7ad0)
Wave2: wv_2 (0x084edf76b0)

See #221.