### PR TITLE
AnalyzeTracingResult: Handle missing INSTRUDATA_FILENAME really grace…

### DIFF
--- a/procedures/unit-testing-tracing.ipf
+++ b/procedures/unit-testing-tracing.ipf
@@ -817,6 +817,12 @@ static Function AnalyzeTracingResult()
 		MultiThread logdata += logdataThread[p][q][r]
 	endfor
 
+	GetFileFolderInfo/P=home/Z/Q INSTRUDATA_FILENAME
+	if(V_flag || !V_IsFile)
+		printf "Error as the instrumentation data does not exist anymore.\r"
+		Abort
+	endif
+
 	LoadWave/P=home/J/K=1/O/Q/M/N=iutf_instrumented_data INSTRUDATA_FILENAME
 	if(V_flag != 1)
 		printf "Error when loading instrumentation data.\r"


### PR DESCRIPTION
…fully

The operation LoadWave does not have a way to prevent a "Missing file dialog". So we have to manually check that the file exists before. Bug introduced in de9e739c (Multiple changes and fixes, 2021-07-15).

This can happen if the experiment is resaved during test run to a different folder, i.e. the path home changes.

Close #285.