### PR TITLE
Enhance error reporting in CHECK_WAVE

### DIFF
--- a/procedures/unit-testing-assertion-checks.ipf
+++ b/procedures/unit-testing-assertion-checks.ipf
@@ -272,14 +272,22 @@ static Function AreWavesEqual(wv1, wv2, mode, tol, detailedMsg)
 	return result
 End
 
-static Function HasWaveMajorType(wv, majorType)
+static Function AddIfFlagSet(var, flag, flagString, str)
+	variable var, flag
+	string flagString
+	string &str
+
+	if((var & flag) == flag)
+		str = AddListItem(flagString, str, ", ")
+	endif
+End
+
+static Function GetWaveMajorType(wv)
 	WAVE/Z wv
-	variable majorType
 
-	variable type, type1, type2
-
-	type2 = WaveType(wv, 2)
-	type1 = WaveType(wv, 1)
+	variable type = 0
+	variable type2 = WaveType(wv, 2)
+	variable type1 = WaveType(wv, 1)
 
 	if(type1 > 0 && type1 <= 4)
 		type = type | 2^(type1 - 1)
@@ -293,18 +301,86 @@ static Function HasWaveMajorType(wv, majorType)
 		type = NULL_WAVE
 	endif
 
-	return (type & majorType) == majorType
+	return type
+End
+
+static Function HasWaveMajorType(wv, majorType)
+	WAVE/Z wv
+	variable majorType
+
+	return (GetWaveMajorType(wv) & majorType) == majorType
+End
+
+static Function/S GetWaveMajorTypeString(type)
+	variable type
+
+	string str = ""
+
+	if((type & NULL_WAVE) == NULL_WAVE)
+		return "NULL_WAVE"
+	endif
+	AddIfFlagSet(type, NUMERIC_WAVE,    "NUMERIC_WAVE",    str)
+	AddIfFlagSet(type, TEXT_WAVE,       "TEXT_WAVE",       str)
+	AddIfFlagSet(type, DATAFOLDER_WAVE, "DATAFOLDER_WAVE", str)
+	AddIfFlagSet(type, WAVE_WAVE,       "WAVE_WAVE",       str)
+	AddIfFlagSet(type, NORMAL_WAVE,     "NORMAL_WAVE",     str)
+	AddIfFlagSet(type, FREE_WAVE,       "FREE_WAVE",       str)
+
+	if(!CmpStr(str, ""))
+		return num2str(type)
+	endif
+
+	return RemoveEnding(str, ", ")
+End
+
+static Function GetWaveMinorType(wv)
+	WAVE/Z wv
+
+	variable type
+
+	if(!WaveExists(wv))
+		return NULL_WAVE
+	endif
+
+	type = WaveType(wv, 0)
+
+	if(type == 0)
+		type = NON_NUMERIC_WAVE
+	endif
+
+	return type
 End
 
 static Function HasWaveMinorType(wv, minorType)
 	WAVE/Z wv
 	variable minorType
 
+	return (GetWaveMinorType(wv) & minorType) == minorType
+End
+
+static Function/S GetWaveMinorTypeString(type)
 	variable type
 
-	type = WaveExists(wv) ? WaveType(wv, 0) : NULL_WAVE
+	string str = ""
 
-	return (type & minorType) == minorType
+	if((type & NULL_WAVE) == NULL_WAVE)
+		return "NULL_WAVE"
+	endif
+	AddIfFlagSet(type, NON_NUMERIC_WAVE, "NON_NUMERIC_WAVE", str)
+	AddIfFlagSet(type, COMPLEX_WAVE,     "COMPLEX_WAVE",     str)
+	AddIfFlagSet(type, FLOAT_WAVE,       "FLOAT_WAVE",       str)
+	AddIfFlagSet(type, DOUBLE_WAVE,      "DOUBLE_WAVE",      str)
+	AddIfFlagSet(type, INT8_WAVE,        "INT8_WAVE",        str)
+	AddIfFlagSet(type, INT16_WAVE,       "INT16_WAVE",       str)
+	AddIfFlagSet(type, INT32_WAVE,       "INT32_WAVE",       str)
+	AddIfFlagSet(type, INT64_WAVE,       "INT64_WAVE",       str)
+	AddIfFlagSet(type, UNSIGNED_WAVE,    "UNSIGNED_WAVE",    str)
+
+	if(!CmpStr(str, ""))
+		return num2str(type)
+	endif
+
+	return RemoveEnding(str, ", ")
 End
 
 /// @endcond // HIDDEN_SYMBOL

--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -509,8 +509,8 @@ static Function TEST_WAVE_WRAPPER(wv, majorType, flags, [minorType])
 	variable majorType, minorType
 	variable flags
 
-	variable result
-	string str
+	variable result, type
+	string str, str1, str2
 
 	incrAssert()
 
@@ -519,12 +519,18 @@ static Function TEST_WAVE_WRAPPER(wv, majorType, flags, [minorType])
 	endif
 
 	result = UTF_Checks#HasWaveMajorType(wv, majorType)
-	sprintf str, "Assumption that the wave's main type is %d", majorType
+	type = UTF_Checks#GetWaveMajorType(wv)
+	str1 = UTF_Checks#GetWaveMajorTypeString(majorType)
+	str2 = UTF_Checks#GetWaveMajorTypeString(type)
+	sprintf str, "Expect wave's main type to be '%s' but got '%s'", str1, str2
 	EvaluateResults(result, str, flags)
 
 	if(!ParamIsDefault(minorType))
 		result = UTF_Checks#HasWaveMinorType(wv, minorType)
-		sprintf str, "Assumption that the wave's sub type is %d", minorType
+		type = UTF_Checks#GetWaveMinorType(wv)
+		str1 = UTF_Checks#GetWaveMinorTypeString(minorType)
+		str2 = UTF_Checks#GetWaveMinorTypeString(type)
+		sprintf str, "Expect wave's sub type to be '%s' but got '%s'", str1, str2
 		EvaluateResults(result, str, flags)
 	endif
 End

--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -518,6 +518,14 @@ static Function TEST_WAVE_WRAPPER(wv, majorType, flags, [minorType])
 		return NaN
 	endif
 
+	if(!(majorType & (NULL_WAVE | NUMERIC_WAVE | TEXT_WAVE | DATAFOLDER_WAVE | WAVE_WAVE | NORMAL_WAVE | FREE_WAVE)))
+		EvaluateResults(0, "Valid major type check", flags)
+		return NaN
+	elseif(!ParamIsDefault(minorType) && !(minorType & (NULL_WAVE | NON_NUMERIC_WAVE | COMPLEX_WAVE | FLOAT_WAVE | DOUBLE_WAVE | INT8_WAVE | INT16_WAVE | INT32_WAVE | INT64_WAVE | UNSIGNED_WAVE)))
+		EvaluateResults(0, "Valid minor type check", flags)
+		return NaN
+	endif
+
 	result = UTF_Checks#HasWaveMajorType(wv, majorType)
 	type = UTF_Checks#GetWaveMajorType(wv)
 	str1 = UTF_Checks#GetWaveMajorTypeString(majorType)

--- a/procedures/unit-testing-constants.ipf
+++ b/procedures/unit-testing-constants.ipf
@@ -41,14 +41,15 @@ Constant REQUIRE_MODE   = 0x07 // == OUTPUT_MESSAGE | INCREASE_ERROR | ABORT_FUN
 
 /// @addtogroup TestWaveFlagsMinor
 ///@{
-Constant COMPLEX_WAVE    = 0x01
-Constant FLOAT_WAVE      = 0x02
-Constant DOUBLE_WAVE     = 0x04
-Constant INT8_WAVE       = 0x08
-Constant INT16_WAVE      = 0x10
-Constant INT32_WAVE      = 0x20
-Constant INT64_WAVE      = 0x80
-Constant UNSIGNED_WAVE   = 0x40
+Constant NON_NUMERIC_WAVE = 0x100
+Constant COMPLEX_WAVE     = 0x01
+Constant FLOAT_WAVE       = 0x02
+Constant DOUBLE_WAVE      = 0x04
+Constant INT8_WAVE        = 0x08
+Constant INT16_WAVE       = 0x10
+Constant INT32_WAVE       = 0x20
+Constant INT64_WAVE       = 0x80
+Constant UNSIGNED_WAVE    = 0x40
 ///@}
 
 /// @addtogroup TestWaveFlagsMajor

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -472,6 +472,7 @@ static Function TestUTF()
 	Ensure(UTF_Checks#HasWaveMinorType($"", NULL_WAVE))
 
 	Make/FREE/D wvDouble
+	Ensure(!UTF_Checks#HasWaveMinorType(wvDouble, NON_NUMERIC_WAVE))
 	Ensure(UTF_Checks#HasWaveMinorType(wvDouble,  DOUBLE_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvDouble, FLOAT_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvDouble, INT8_WAVE))
@@ -494,6 +495,7 @@ static Function TestUTF()
 	Ensure(!UTF_Checks#HasWaveMinorType(wvDouble, INT64_WAVE  | COMPLEX_WAVE | UNSIGNED_WAVE))
 
 	Make/FREE/W wvInt16
+	Ensure(!UTF_Checks#HasWaveMinorType(wvInt16, NON_NUMERIC_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvInt16,  DOUBLE_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvInt16, FLOAT_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvInt16, INT8_WAVE))
@@ -516,6 +518,7 @@ static Function TestUTF()
 	Ensure(!UTF_Checks#HasWaveMinorType(wvInt16, INT64_WAVE  | COMPLEX_WAVE | UNSIGNED_WAVE))
 
 	Make/FREE/W/U wvUInt16
+	Ensure(!UTF_Checks#HasWaveMinorType(wvUInt16, NON_NUMERIC_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUInt16,  DOUBLE_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUInt16, FLOAT_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUInt16, INT8_WAVE))
@@ -538,6 +541,7 @@ static Function TestUTF()
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUInt16, INT64_WAVE  | COMPLEX_WAVE | UNSIGNED_WAVE))
 
 	Make/FREE/W/U/C wvUInt16Complex
+	Ensure(!UTF_Checks#HasWaveMinorType(wvUInt16Complex, NON_NUMERIC_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUInt16Complex, DOUBLE_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUInt16Complex, FLOAT_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUInt16Complex, INT8_WAVE))
@@ -562,6 +566,7 @@ static Function TestUTF()
 #if IgorVersion() >= 7.0
 
 	Make/FREE/L/U wvUint64
+	Ensure(!UTF_Checks#HasWaveMinorType(wvUint64, NON_NUMERIC_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUint64, DOUBLE_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUint64, FLOAT_WAVE))
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUint64, INT8_WAVE))
@@ -584,6 +589,29 @@ static Function TestUTF()
 	Ensure(!UTF_Checks#HasWaveMinorType(wvUint64, INT64_WAVE  | COMPLEX_WAVE | UNSIGNED_WAVE))
 
 #endif
+
+	Make/FREE/T wvText
+	Ensure(UTF_CHECKS#HasWaveMinorType(wvText, NON_NUMERIC_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, DOUBLE_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, FLOAT_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT8_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT16_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT32_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT64_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, DOUBLE_WAVE | COMPLEX_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, FLOAT_WAVE  | COMPLEX_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT8_WAVE   | COMPLEX_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT16_WAVE  | COMPLEX_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT32_WAVE  | COMPLEX_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT64_WAVE  | COMPLEX_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT8_WAVE   | UNSIGNED_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT16_WAVE  | UNSIGNED_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT32_WAVE  | UNSIGNED_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT64_WAVE   | UNSIGNED_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT8_WAVE   | COMPLEX_WAVE | UNSIGNED_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT16_WAVE  | COMPLEX_WAVE | UNSIGNED_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT32_WAVE  | COMPLEX_WAVE | UNSIGNED_WAVE))
+	Ensure(!UTF_Checks#HasWaveMinorType(wvText, INT64_WAVE  | COMPLEX_WAVE | UNSIGNED_WAVE))
 
 #if IgorVersion() >= 7.0
 

--- a/tests/Various.ipf
+++ b/tests/Various.ipf
@@ -453,6 +453,84 @@ static Function TC_StringDiff_Check(str1, str2, out1, out2, [case_sensitive])
 	CHECK_EQUAL_STR(out1, str)
 End
 
+static Function TC_WaveMajorTypeString()
+	// just the constants
+	TC_WaveMajorTypeString_Check("NULL_WAVE", NULL_WAVE)
+	TC_WaveMajorTypeString_Check("NUMERIC_WAVE", NUMERIC_WAVE)
+	TC_WaveMajorTypeString_Check("TEXT_WAVE", TEXT_WAVE)
+	TC_WaveMajorTypeString_Check("DATAFOLDER_WAVE", DATAFOLDER_WAVE)
+	TC_WaveMajorTypeString_Check("WAVE_WAVE", WAVE_WAVE)
+	TC_WaveMajorTypeString_Check("NORMAL_WAVE", NORMAL_WAVE)
+	TC_WaveMajorTypeString_Check("FREE_WAVE", FREE_WAVE)
+
+	// normal waves
+	TC_WaveMajorTypeString_Check("NULL_WAVE", NORMAL_WAVE | NULL_WAVE)
+	TC_WaveMajorTypeString_Check("NORMAL_WAVE, NUMERIC_WAVE", NORMAL_WAVE | NUMERIC_WAVE)
+	TC_WaveMajorTypeString_Check("NORMAL_WAVE, TEXT_WAVE", NORMAL_WAVE | TEXT_WAVE)
+	TC_WaveMajorTypeString_Check("NORMAL_WAVE, DATAFOLDER_WAVE", NORMAL_WAVE | DATAFOLDER_WAVE)
+	TC_WaveMajorTypeString_Check("NORMAL_WAVE, WAVE_WAVE", NORMAL_WAVE | WAVE_WAVE)
+
+	// free waves
+	TC_WaveMajorTypeString_Check("NULL_WAVE", FREE_WAVE | NULL_WAVE)
+	TC_WaveMajorTypeString_Check("FREE_WAVE, NUMERIC_WAVE", FREE_WAVE | NUMERIC_WAVE)
+	TC_WaveMajorTypeString_Check("FREE_WAVE, TEXT_WAVE", FREE_WAVE | TEXT_WAVE)
+	TC_WaveMajorTypeString_Check("FREE_WAVE, DATAFOLDER_WAVE", FREE_WAVE | DATAFOLDER_WAVE)
+	TC_WaveMajorTypeString_Check("FREE_WAVE, WAVE_WAVE", FREE_WAVE | WAVE_WAVE)
+End
+
+static Function TC_WaveMajorTypeString_Check(expected, type)
+	string expected
+	variable type
+
+	string str
+
+	str = UTF_Checks#GetWaveMajorTypeString(type)
+	CHECK_EQUAL_STR(expected, str)
+End
+
+static Function TC_WaveMinorTypeString()
+	// just the constants
+	TC_WaveMinorTypeString_Check("NON_NUMERIC_WAVE", NON_NUMERIC_WAVE)
+	TC_WaveMinorTypeString_Check("COMPLEX_WAVE", COMPLEX_WAVE)
+	TC_WaveMinorTypeString_Check("FLOAT_WAVE", FLOAT_WAVE)
+	TC_WaveMinorTypeString_Check("DOUBLE_WAVE", DOUBLE_WAVE)
+	TC_WaveMinorTypeString_Check("INT8_WAVE", INT8_WAVE)
+	TC_WaveMinorTypeString_Check("INT16_WAVE", INT16_WAVE)
+	TC_WaveMinorTypeString_Check("INT32_WAVE", INT32_WAVE)
+	TC_WaveMinorTypeString_Check("INT64_WAVE", INT64_WAVE)
+	TC_WaveMinorTypeString_Check("UNSIGNED_WAVE", UNSIGNED_WAVE)
+
+	// unsigned waves
+	TC_WaveMinorTypeString_Check("UNSIGNED_WAVE, INT8_WAVE",  UNSIGNED_WAVE | INT8_WAVE)
+	TC_WaveMinorTypeString_Check("UNSIGNED_WAVE, INT16_WAVE", UNSIGNED_WAVE | INT16_WAVE)
+	TC_WaveMinorTypeString_Check("UNSIGNED_WAVE, INT32_WAVE", UNSIGNED_WAVE | INT32_WAVE)
+	TC_WaveMinorTypeString_Check("UNSIGNED_WAVE, INT64_WAVE", UNSIGNED_WAVE | INT64_WAVE)
+
+	// complex waves
+	TC_WaveMinorTypeString_Check("FLOAT_WAVE, COMPLEX_WAVE", FLOAT_WAVE | COMPLEX_WAVE)
+	TC_WaveMinorTypeString_Check("DOUBLE_WAVE, COMPLEX_WAVE", DOUBLE_WAVE | COMPLEX_WAVE)
+	TC_WaveMinorTypeString_Check("INT8_WAVE, COMPLEX_WAVE", INT8_WAVE | COMPLEX_WAVE)
+	TC_WaveMinorTypeString_Check("INT16_WAVE, COMPLEX_WAVE", INT16_WAVE | COMPLEX_WAVE)
+	TC_WaveMinorTypeString_Check("INT32_WAVE, COMPLEX_WAVE", INT32_WAVE | COMPLEX_WAVE)
+	TC_WaveMinorTypeString_Check("INT64_WAVE, COMPLEX_WAVE", INT64_WAVE | COMPLEX_WAVE)
+
+	// unsigned complex waves
+	TC_WaveMinorTypeString_Check("UNSIGNED_WAVE, INT8_WAVE, COMPLEX_WAVE", UNSIGNED_WAVE | INT8_WAVE | COMPLEX_WAVE)
+	TC_WaveMinorTypeString_Check("UNSIGNED_WAVE, INT16_WAVE, COMPLEX_WAVE", UNSIGNED_WAVE | INT16_WAVE | COMPLEX_WAVE)
+	TC_WaveMinorTypeString_Check("UNSIGNED_WAVE, INT32_WAVE, COMPLEX_WAVE", UNSIGNED_WAVE | INT32_WAVE | COMPLEX_WAVE)
+	TC_WaveMinorTypeString_Check("UNSIGNED_WAVE, INT64_WAVE, COMPLEX_WAVE", UNSIGNED_WAVE | INT64_WAVE | COMPLEX_WAVE)
+End
+
+static Function TC_WaveMinorTypeString_Check(expected, type)
+	string expected
+	variable type
+
+	string str
+
+	str = UTF_Checks#GetWaveMinorTypeString(type)
+	CHECK_EQUAL_STR(expected, str)
+End
+
 // UTF_EXPECTED_FAILURE
 static Function TC_BreaksHard()
 


### PR DESCRIPTION
Makes the output of the wave type more user understandable. This shows the specific type as a string which contains the same names as the flags that are used to specify the type in CHECK_WAVE.

Close #220.