### PR TITLE
Enhance multiline string diff output

### DIFF
--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -461,6 +461,7 @@ static Function EQUAL_STR_WRAPPER(str1, str2, flags, [case_sensitive])
 
 	variable result
 	string str, tmpStr1, tmpStr2
+	Struct IUTF_StringDiffResult diffResult
 
 	incrAssert()
 
@@ -473,10 +474,11 @@ static Function EQUAL_STR_WRAPPER(str1, str2, flags, [case_sensitive])
 	endif
 
 	result = UTF_Checks#AreStringsEqual(str1, str2, case_sensitive)
-	tmpStr1 = UTF_Utils#PrepareStringForOut(str1)
-	tmpStr2 = UTF_Utils#PrepareStringForOut(str2)
-	sprintf str, "\"%s\" == \"%s\" %s case", tmpStr1, tmpStr2, SelectString(case_sensitive, "not respecting", "respecting")
-	EvaluateResults(result, str, flags)
+	if(!result)
+		UTF_Utils#DiffString(str1, str2, diffResult, case_sensitive=case_sensitive)
+		sprintf str, "String mismatch (case %ssensitive):\rstr1: %s\rstr2: %s\r", SelectString(case_sensitive, "in", ""), diffResult.v1, diffResult.v2
+		EvaluateResults(result, str, flags)
+	endif
 End
 
 /// @class WAVE_DOCU

--- a/tests/Various.ipf
+++ b/tests/Various.ipf
@@ -407,6 +407,8 @@ static Function TC_StringDiff()
 
 	// Case sensitivity
 	TC_StringDiff_Check("a\nb", "A\nc", "0:0:0> a", "0:0:0> A")
+	TC_StringDiff_Check("a\nb", "A\nc", "1:0:2> b", "1:0:2> c", case_sensitive=0)
+	TC_StringDiff_Check("a\nb", "A\nc", "0:0:0> a", "0:0:0> A", case_sensitive=1)
 
 	// Trim context
 	TC_StringDiff_Check("0123456789abcdef.0123456789abcdef", "0123456789abcdef:0123456789abcdef", "0:16:16> 6 7 8 9 a b c d e f . 0 1 2 3 4 5 6 7 8 9", "0:16:16> 6 7 8 9 a b c d e f : 0 1 2 3 4 5 6 7 8 9")
@@ -421,21 +423,30 @@ static Function TC_StringDiff()
 	CHECK_EQUAL_STR(expected, res)
 End
 
-static Function TC_StringDiff_Check(str1, str2, out1, out2)
+static Function TC_StringDiff_Check(str1, str2, out1, out2, [case_sensitive])
 	string str1, str2, out1, out2
-	Struct IUTF_StringDiffResult result
+	variable case_sensitive
 
+	Struct IUTF_StringDiffResult result
 	string str
 
 	// forward check
-	UTF_UTILS#DiffString(str1, str2, result)
+	if(ParamIsDefault(case_sensitive))
+		UTF_UTILS#DiffString(str1, str2, result)
+	else
+		UTF_UTILS#DiffString(str1, str2, result, case_sensitive=case_sensitive)
+	endif
 	str = result.v1
 	CHECK_EQUAL_STR(out1, str)
 	str = result.v2
 	CHECK_EQUAL_STR(out2, str)
 
 	// backward check (switched arguments)
-	UTF_UTILS#DiffString(str2, str1, result)
+	if(ParamIsDefault(case_sensitive))
+		UTF_UTILS#DiffString(str2, str1, result)
+	else
+		UTF_UTILS#DiffString(str2, str1, result, case_sensitive=case_sensitive)
+	endif
 	str = result.v1
 	CHECK_EQUAL_STR(out2, str)
 	str = result.v2


### PR DESCRIPTION
CHECK_EQUAL_STR, WARN_EQUAL_STR, REQUIRE_EQUAL_STR printed the full content of both strings if there was a mismatch. This is changed using the new string diffing technique introduced in PR #275 for text waves. The new output will only contain the first difference in both strings and some context around.

The new output look like this:

```
String mismatch (case insensitive):
str1: 0:0:0> a
str2: 0:0:0> b
: is false. Assertion "WARN_EQUAL_STR(a, b)" failed in line 13, procedure "Various.ipf"
```

Close #104