### PR TITLE
CI: Specify timeout and retry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,13 @@
 # This file is a template, and might need editing before it works on your project.
 # see https://docs.gitlab.com/ce/ci/yaml/README.html for all available options
 
+default:
+  timeout: 3 minutes
+  retry:
+    max: 1
+    when:
+      - stuck_or_timeout_failure
+
 pre-commit:
   tags:
     - debian, docker
@@ -154,6 +161,7 @@ deployment_staging:
     - debian, docker
   image:
     name: ${CI_REGISTRY}/internal/docker-utils:latest
+  timeout: 10 minutes
   variables:
     DOCKER_AUTH_CONFIG: "${DOCKER_AUTH_CONFIG_UTILS}"
   script:
@@ -172,6 +180,7 @@ deployment:
     - debian, docker
   image:
     name: ${CI_REGISTRY}/internal/docker-utils:latest
+  timeout: 10 minutes
   variables:
     DOCKER_AUTH_CONFIG: "${DOCKER_AUTH_CONFIG_UTILS}"
   script:


### PR DESCRIPTION
Set the default timeout for any job to 3 minutes. This time is right now
clamped to 10 minutes because GitLab doesn't support smaller values
right now. [1]

Enable timeout jobs to retry one time. This can happens most times if
Igor is stuck again.

[1]: https://gitlab.com/gitlab-org/gitlab/-/issues/23184

Close: #301.