### PR TITLE
IsVariableSmall: Change tolerance

### DIFF
--- a/procedures/unit-testing-assertion-checks.ipf
+++ b/procedures/unit-testing-assertion-checks.ipf
@@ -98,7 +98,7 @@ static Function IsVariableSmall(var, tol)
 	variable var
 	variable tol
 
-	return (abs(var) < abs(tol))
+	return (abs(var) <= abs(tol))
 End
 
 #if IgorVersion() >= 7.0

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -248,6 +248,8 @@ static Function TestUTF()
 	Ensure(!UTF_Checks#IsVariableSmall(-(DEFAULT_TOLERANCE + 1e-15), DEFAULT_TOLERANCE))
 	Ensure(!UTF_Checks#IsVariableSmall(DEFAULT_TOLERANCE + 1e-15, DEFAULT_TOLERANCE))
 	Ensure(!UTF_Checks#IsVariableSmall(-(DEFAULT_TOLERANCE + 1e-15), DEFAULT_TOLERANCE))
+	Ensure(UTF_Checks#IsVariableSmall(0, 0))
+	Ensure(UTF_Checks#IsVariableSmall(1, 1))
 	// @}
 
 	CHECK_SMALL_VAR(DEFAULT_TOLERANCE - 1e-15)


### PR DESCRIPTION
Enables variables in IsVariableSmall to be the same size as the
tolerance to be considered small. Before it has to be smaller than the
tolerance which is unintuitive.

See PR #308.