### PR TITLE
FIX: error counter for test assertions

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -739,20 +739,23 @@ End
 ///                 summary.
 /// @param hideInSummary (optional, default disabled) If set to non zero it will hide this message
 ///                 in the summary at the end of the test run.
-static Function TestCaseFail(message, [summaryMsg, hideInSummary])
+/// @param  incrErrorCounter (optional, default enabled) Enabled if set to a value different to 0.
+///                 Increases the internal error counter.
+static Function TestCaseFail(message, [summaryMsg, hideInSummary, incrErrorCounter])
 	string message
 	string summaryMsg
-	variable hideInSummary
+	variable hideInSummary, incrErrorCounter
 
 	DFREF dfr = GetPackageFolder()
 	SVAR/SDFR=dfr type
 
 	summaryMsg = SelectString(ParamIsDefault(summaryMsg), summaryMsg, message)
 	hideInSummary = ParamIsDefault(hideInSummary) ? 0 : !!hideInSummary
+	incrErrorCounter = ParamIsDefault(incrErrorCounter) ? 1 : !!incrErrorCounter
 
 	SetTestStatus(message)
 	type = "FAIL"
-	ReportError(message)
+	ReportError(message, incrErrorCounter = incrErrorCounter)
 
 	if(!hideInSummary)
 		AddFailedSummaryInfo(summaryMsg)
@@ -779,7 +782,7 @@ Function PrintFailInfo(expectedFailure)
 	str = getInfo(0)
 	message = prefix + status + " " + str
 
-	TestCaseFail(message, summaryMsg = str, hideInSummary = !!expectedFailure)
+	TestCaseFail(message, summaryMsg = str, hideInSummary = !!expectedFailure, incrErrorCounter = 0)
 End
 
 /// Returns 1 if the abortFlag is set and zero otherwise


### PR DESCRIPTION
During some refactoring of the handling of internal error messages the
error counter got broken. It will increase the error always by one for
each error printing even it was an expected error.

This is now fixed as such as an option was introduced to select if the
error counter should be increased (normally used by UTF errors) or not
(normally the case for UTF assertions).

Close: #311.