### PR TITLE
Bug-Fix: missing assertion name

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -919,7 +919,7 @@ static Function/S getInfo(result)
 	NVAR/SDFR=dfr assert_count
 	string caller, func, procedure, callStack, contents, moduleName
 	string text, cleanText, line, callerTestCase, tmpStr
-	variable numCallers, i
+	variable numCallers, i, assertLine
 	variable callerIndex = NaN
 	variable testCaseIndex
 
@@ -959,10 +959,11 @@ static Function/S getInfo(result)
 
 	callerTestCase = StringFromList(testCaseIndex, callStack)
 
-	caller    = StringFromList(callerIndex, callStack)
-	func      = StringFromList(0, caller, ",")
-	procedure = StringFromList(1, caller, ",")
-	line      = StringFromList(2, caller, ",")
+	caller     = StringFromList(callerIndex, callStack)
+	func       = StringFromList(0, caller, ",")
+	procedure  = StringFromList(1, caller, ",")
+	line       = StringFromList(2, caller, ",")
+	assertLine = str2num(StringFromList(2, caller, ","))
 
 	if(callerIndex != testcaseIndex)
 		func = StringFromList(0, callerTestCase, ",") + TC_ASSERTION_MLINE_INDICATOR + func
@@ -974,7 +975,7 @@ static Function/S getInfo(result)
 	endif
 
 	contents = ProcedureText("", -1, procedure)
-	text = StringFromList(str2num(line), contents, "\r")
+	text = StringFromList(assertLine, contents, "\r")
 
 	cleanText = trimstring(text)
 

--- a/tests/Various.ipf
+++ b/tests/Various.ipf
@@ -7,6 +7,18 @@
 
 static Constant MMD_COMBO_COUNT = 32
 
+// this is used for checking warnings in the history
+Function TriggerWarningToHistory()
+	DoWindow/K HistoryCarbonCopy
+	NewNotebook/V=0/F=0 /N=HistoryCarbonCopy
+	WARN(0)
+End
+
+Function CheckForWarningInHistory()
+	Notebook HistoryCarbonCopy, findText={"Assertion \"WARN(0)\" failed in TriggerWarningToHistory", 19}
+	CHECK_EQUAL_VAR(1, V_flag)
+End
+
 Function DoesNotBugOutOnLongString()
 
 	string a = PadString("a", 10e4, 0x20)


### PR DESCRIPTION
During the changes in 09a1dfc (Output summary at the end of test run,
2022-11-11) the output of the assertion message got broken. The message
won't show any longer the assertion line that triggered the error.

A testcase is added to Various to prevent this error in the future.

Fix: #321