### PR TITLE
Bug-Fix: Fix undefined global var references

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -698,7 +698,12 @@ static Function AddMessageToBuffer()
 	DFREF dfr = GetPackageFolder()
 	SVAR/SDFR=dfr message
 	SVAR/SDFR=dfr type
-	WAVE/T/SDFR=dfr messageBuffer
+	WAVE/T/SDFR=dfr/Z messageBuffer
+
+	if(!WaveExists(messageBuffer))
+		initMessageBuffer()
+		WAVE/T/SDFR=dfr messageBuffer
+	endif
 
 	size = DimSize(messageBuffer, UTF_ROW)
 	Redimension/N=(size + 1, -1) messageBuffer
@@ -3570,6 +3575,11 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 	InitStrRunTest(s)
 
 	DFREF dfr = GetPackageFolder()
+
+	// init global vars
+	string/G dfr:message = ""
+	string/G dfr:type = "0"
+	string/G dfr:systemErr = ""
 
 	// do not save these for reentry
 	//


### PR DESCRIPTION
In 9144af0 (Simplify the report of internal errors, 2022-11-03) the
output for internal errors has been simplified. In some cases is
UTF_ToSystemErrorStream called before it's global variable is
initialized which produce a RTE error.

The global variables dfr:messageBuffer, dfr:message, dfr:type and
dfr:systemErr are now as early as possible initialized to prevent access
errors later.

Fix: #318