### PR TITLE
Use UTF_PrintStatusMessage instead of printf

### DIFF
--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -224,8 +224,8 @@ static Function NEQ_STR_WRAPPER(str1, str2, flags, [case_sensitive])
 	endif
 
 	result = !UTF_Checks#AreStringsEqual(str1, str2, case_sensitive)
-	tmpStr1 = UTF_Utils#PrepareStringForOut(str1)
-	tmpStr2 = UTF_Utils#PrepareStringForOut(str2)
+	tmpStr1 = UTF_Utils#IUTF_PrepareStringForOut(str1)
+	tmpStr2 = UTF_Utils#IUTF_PrepareStringForOut(str2)
 	sprintf str, "\"%s\" != \"%s\" %s case", tmpStr1, tmpStr2, SelectString(case_sensitive, "not respecting", "respecting")
 
 	EvaluateResults(result, str, flags)

--- a/procedures/unit-testing-autorun.ipf
+++ b/procedures/unit-testing-autorun.ipf
@@ -125,19 +125,20 @@ End
 /// in the same folder as this experiment as timestamped file "run_*_*.log"
 Function SaveHistoryLog()
 
-	string historyLog
+	string historyLog, msg
 	historyLog = GetBaseFilename() + ".log"
 
 	DoWindow HistoryCarbonCopy
 	if(V_flag == 0)
-		print "No log notebook found, please call CreateHistoryLog() before."
+		UTF_Reporting#UTF_PrintStatusMessage("No log notebook found, please call CreateHistoryLog() before.")
 		return NaN
 	endif
 
 	PathInfo home
 	historyLog = getUnusedFileName(S_path + historyLog)
 	if(UTF_Utils#IsEmpty(historyLog))
-		printf "Error: Unable to determine unused file name for History Log output in path %s !", S_path
+		sprintf msg, "Error: Unable to determine unused file name for History Log output in path %s !", S_path
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return NaN
 	endif
 

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -256,8 +256,8 @@ Function GenerateDimLabelDifference(wv1, wv2, msg)
 			str2 = GetDimLabel(wv2, i, -1)
 
 			if(cmpstr(str1, str2))
-				tmpStr1 = UTF_Utils#PrepareStringForOut(str1)
-				tmpStr2 = UTF_Utils#PrepareStringForOut(str2)
+				tmpStr1 = UTF_Utils#IUTF_PrepareStringForOut(str1)
+				tmpStr2 = UTF_Utils#IUTF_PrepareStringForOut(str2)
 				sprintf msg, "Dimension labels for the entire dimension %d differ: %s vs %s", i, tmpStr1, tmpStr2
 				return 0
 			endif
@@ -278,8 +278,8 @@ Function GenerateDimLabelDifference(wv1, wv2, msg)
 				endif
 				str1 = label1[j]
 				str2 = label2[j]
-				tmpStr1 = UTF_Utils#PrepareStringForOut(str1)
-				tmpStr2 = UTF_Utils#PrepareStringForOut(str2)
+				tmpStr1 = UTF_Utils#IUTF_PrepareStringForOut(str1)
+				tmpStr2 = UTF_Utils#IUTF_PrepareStringForOut(str2)
 				sprintf msg, "Differing dimension label in dimension %d at index %d: %s vs %s", i, j, tmpStr1, tmpStr2
 				return 0
 			endfor
@@ -3187,13 +3187,13 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 		if(err != TC_MATCH_OK)
 			if(err == TC_LIST_EMPTY)
 				errMsg = s.procWinList
-				errMsg = UTF_Utils#PrepareStringForOut(errMsg)
+				errMsg = UTF_Utils#IUTF_PrepareStringForOut(errMsg)
 				sprintf msg, "Error: A test case matching the pattern \"%s\" could not be found in test suite(s) \"%s\".", s.testcase, errMsg
 				UTF_Reporting#ReportError(msg)
 				return NaN
 			endif
 
-			errMsg = UTF_Utils#PrepareStringForOut(errMsg)
+			errMsg = UTF_Utils#IUTF_PrepareStringForOut(errMsg)
 			sprintf msg, "Error %d in CreateTestRunSetup: %s", err, errMsg
 			UTF_Reporting#ReportError(msg)
 			return NaN

--- a/procedures/unit-testing-junit.ipf
+++ b/procedures/unit-testing-junit.ipf
@@ -240,7 +240,7 @@ End
 /// Writes JUNIT XML output to derived file name
 static Function JU_WriteOutput()
 	variable fnum, i, childStart, childEnd
-	string out, juFileName
+	string out, juFileName, msg
 
 	WAVE/T wvTestRun = UTF_Reporting#GetTestRunWave()
 	childStart = str2num(wvTestRun[%CURRENT][%CHILD_START])
@@ -259,7 +259,8 @@ static Function JU_WriteOutput()
 	PathInfo home
 	juFileName = getUnusedFileName(S_path + "JU_" + GetBaseFilename() + ".xml")
 	if(UTF_Utils#IsEmpty(juFileName))
-		printf "Error: Unable to determine unused file name for JUNIT output in path %s !\r", S_path
+		sprintf msg, "Error: Unable to determine unused file name for JUNIT output in path %s !", S_path
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return NaN
 	endif
 
@@ -269,7 +270,8 @@ static Function JU_WriteOutput()
 		close fnum
 	else
 		PathInfo home
-		printf "Error: Could not create JUNIT output file at %s\r", S_path + juFileName
+		sprintf msg, "Error: Could not create JUNIT output file at %s", S_path + juFileName
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 	endif
 End
 

--- a/procedures/unit-testing-reporting.ipf
+++ b/procedures/unit-testing-reporting.ipf
@@ -492,7 +492,7 @@ static Function/S getInfo(result, partialStack)
 
 	cleanText = trimstring(text)
 
-	tmpStr = UTF_Utils#PrepareStringForOut(cleanText)
+	tmpStr = UTF_Utils#IUTF_PrepareStringForOut(cleanText)
 	sprintf text, "Assertion \"%s\" %s in %s%s (%s, line %s)", tmpStr, SelectString(result, "failed", "succeeded"), func, moduleName, procedure, line
 	return text
 End
@@ -563,7 +563,7 @@ static Function UTF_PrintStatusMessage(msg)
 #if	(IgorVersion() >= 9.0)
 	fprintf -1, "%s\r\n", msg
 #elif (IgorVersion() >= 8.0)
-	tmpStr = UTF_Utils#PrepareStringForOut(msg, maxLen = IP8_PRINTF_STR_MAX_LENGTH - 2)
+	tmpStr = IUTF_PrepareStringForOut(msg, maxLen = IP8_PRINTF_STR_MAX_LENGTH - 2)
 	fprintf -1, "%s\r\n", tmpStr
 #endif
 End

--- a/procedures/unit-testing-reporting.ipf
+++ b/procedures/unit-testing-reporting.ipf
@@ -541,7 +541,7 @@ End
 /// Always use this function if you want to inform the user about something.
 ///
 /// @param msg message to be outputted, without trailing end-of-line
-static Function UTF_PrintStatusMessage(msg)
+threadsafe static Function UTF_PrintStatusMessage(msg)
 	string msg
 
 	string tmpStr

--- a/procedures/unit-testing-tap.ipf
+++ b/procedures/unit-testing-tap.ipf
@@ -109,7 +109,7 @@ static Function/S TAP_ToTestCaseString(testCaseIndex, caseCount)
 	variable testCaseIndex
 	variable caseCount
 
-	string name, out, ok, diagnostics, description, directive, caseCountStr, prefix
+	string name, out, ok, diagnostics, description, directive, caseCountStr, msg, prefix
 	variable err
 
 	WAVE/T wvTestCase = UTF_Reporting#GetTestCaseWave()
@@ -145,7 +145,8 @@ static Function/S TAP_ToTestCaseString(testCaseIndex, caseCount)
 			diagnostics = TAP_ValidDiagnostic(diagnostics)
 			break
 		default:
-			printf "Error: Unknown test status %s for test case %s (%d)\r", wvTestCase[testCaseIndex][%STATUS], name, testCaseIndex
+			sprintf msg, "Error: Unknown test status %s for test case %s (%d)", wvTestCase[testCaseIndex][%STATUS], name, testCaseIndex
+			UTF_Reporting#UTF_PrintStatusMessage(msg)
 			return ""
 	endswitch
 
@@ -185,21 +186,23 @@ End
 static Function TAP_Write()
 
 	variable fnum, i, childStart, childEnd
-	string filename, s
+	string filename, s, msg
 	variable caseCount = 1
 
 	filename = "tap_" + GetBaseFilename() + ".log"
 	PathInfo home
 	filename = getUnusedFileName(S_path + filename)
 	if(!strlen(filename))
-		printf "Error: Unable to determine unused file name for TAP output in path %s !", S_path
+		sprintf msg, "Error: Unable to determine unused file name for TAP output in path %s !", S_path
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return NaN
 	endif
 
 	open/Z/P=home fnum as filename
 	if(V_flag)
 		PathInfo home
-		printf "Error: Could not create TAP output file at %s\r", S_path + filename
+		sprintf msg, "Error: Could not create TAP output file at %s", S_path + filename
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return NaN
 	endif
 

--- a/procedures/unit-testing-tracing-analytics.ipf
+++ b/procedures/unit-testing-tracing-analytics.ipf
@@ -129,6 +129,7 @@ End
 
 static Function/WAVE SearchHighestWithMeta(WAVE/T procs, STRUCT CollectionResult &collectionResult, variable sorting)
 	variable i, searchIndex, metaIndex
+	string msg
 
 	Make/FREE=1/N=(collectionResult.count, 5)/T result
 	SetDimLabel UTF_COLUMN, 0, 'Function Calls', result
@@ -148,7 +149,8 @@ static Function/WAVE SearchHighestWithMeta(WAVE/T procs, STRUCT CollectionResult
 		WAVE metaWave = collectionResult.calls
 		metaIndex = 0
 	else
-		printf "Bug: Sorting %d is not supported\r", sorting
+		sprintf msg, "Bug: Sorting %d is not supported", sorting
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return result
 	endif
 
@@ -171,6 +173,7 @@ End
 
 static Function/WAVE SearchHighest(WAVE/T procs, STRUCT CollectionResult &collectionResult, variable sorting)
 	variable i
+	string msg
 
 	Make/FREE=1/N=(collectionResult.count, 4)/T result
 	SetDimLabel UTF_COLUMN, 0, Calls, result
@@ -181,7 +184,8 @@ static Function/WAVE SearchHighest(WAVE/T procs, STRUCT CollectionResult &collec
 	if(sorting == UTF_ANALYTICS_CALLS)
 		WAVE searchWave = collectionResult.calls
 	else
-		printf "Bug: Sorting %d is not supported\r", sorting
+		sprintf msg, "Bug: Sorting %d is not supported", sorting
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return result
 	endif
 
@@ -247,30 +251,33 @@ Function ShowTopFunctions(variable count, [variable mode, variable sorting])
 	sorting = ParamIsDefault(sorting) ? UTF_ANALYTICS_CALLS : sorting
 
 	if(mode != UTF_ANALYTICS_FUNCTIONS && mode != UTF_ANALYTICS_LINES)
-		printf "Mode %d is an unsupported mode\r", mode
+		sprintf msg, "Mode %d is an unsupported mode", mode
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return NaN
 	endif
 	if(sorting != UTF_ANALYTICS_CALLS && sorting != UTF_ANALYTICS_SUM)
-		printf "Sorting %d is an unsupported sorting\r", sorting
+		sprintf msg, "Sorting %d is an unsupported sorting", sorting
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return NaN
 	endif
 	if(sorting == UTF_ANALYTICS_SUM && mode != UTF_ANALYTICS_FUNCTIONS)
-		printf "Sum sorting is only available for the functions mode\r"
+		UTF_Reporting#UTF_PrintStatusMessage("Sum sorting is only available for the functions mode")
 		return NaN
 	endif
 	if(count < 0 || UTF_Utils#IsNaN(count))
-		printf "Invalid count: %d\r", count
+		sprintf msg, "Invalid count: %d", count
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return NaN
 	endif
 	if(!HasTracingData())
-		printf "No Tracing data exists. Try to run tracing first.\r"
+		UTF_Reporting#UTF_PrintStatusMessage("No Tracing data exists. Try to run tracing first.")
 		return NaN
 	endif
 
 	WAVE totals = GetTotals()
 	if(!DimSize(totals, UTF_ROW))
 		// this can happen after stored Experiment is loaded to a fresh instance of Igor
-		printf "TUFXOP has no data. Try to rerun tracing to get new data.\r"
+		UTF_Reporting#UTF_PrintStatusMessage("TUFXOP has no data. Try to rerun tracing to get new data.")
 		return NaN
 	endif
 
@@ -279,7 +286,8 @@ Function ShowTopFunctions(variable count, [variable mode, variable sorting])
 	elseif(mode == UTF_ANALYTICS_LINES)
 		CollectLines(totals, procs, collectionResult)
 	else
-		printf "Bug: Unknown mode %d for collection\r", mode
+		sprintf msg, "Bug: Unknown mode %d for collection", mode
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return NaN
 	endif
 
@@ -292,14 +300,15 @@ Function ShowTopFunctions(variable count, [variable mode, variable sorting])
 	elseif(mode == UTF_ANALYTICS_LINES)
 		WAVE/T result = SearchHighest(procs, collectionResult, sorting)
 	else
-		printf "Bug: Unknown mode %d for sorting\r", mode
+		sprintf msg, "Bug: Unknown mode %d for sorting", mode
+		UTF_Reporting#UTF_PrintStatusMessage(msg)
 	endif
 
 	Duplicate/O result, dfr:TracingAnalyticResult
 
 	header = GetWaveHeader(result)
 	msg = UTF_Utils#NicifyTableText(result, header)
-	printf "Result:\r%s\r", msg
+	UTF_Reporting#UTF_PrintStatusMessage(msg)
 End
 
 #endif

--- a/procedures/unit-testing-tracing-tracer.ipf
+++ b/procedures/unit-testing-tracing-tracer.ipf
@@ -40,12 +40,12 @@ threadsafe Function Z_(variable procNum, variable lineNum[, variable c, variable
 		err = V_flag
 		TUFXOP_Init/Z/Q/N="IUTF_Error"
 		if(V_flag)
-			printf "No gathered tracing data found for code coverage analysis.\r"
+			UTF_Reporting#UTF_PrintStatusMessage("No gathered tracing data found for code coverage analysis.")
 			return c
 		endif
 		TUFXOP_GetStorage/Z/Q/N="IUTF_Error"/TS wvStorage
 		if(V_flag)
-			printf "No gathered tracing data found for code coverage analysis.\r"
+			UTF_Reporting#UTF_PrintStatusMessage("No gathered tracing data found for code coverage analysis.")
 			return c
 		endif
 		if(!WaveExists(wvStorage[0]))
@@ -60,7 +60,7 @@ threadsafe Function Z_(variable procNum, variable lineNum[, variable c, variable
 		TUFXOP_Init/N="IUTF_Testrun"
 		TUFXOP_GetStorage/Z/Q/N="IUTF_Testrun"/TS wref
 		if(V_flag)
-			printf "No gathered tracing data found for code coverage analysis.\r"
+			UTF_Reporting#UTF_PrintStatusMessage("No gathered tracing data found for code coverage analysis.")
 			return c
 		endif
 	endif

--- a/procedures/unit-testing-tracing.ipf
+++ b/procedures/unit-testing-tracing.ipf
@@ -462,8 +462,10 @@ static Function [WAVE/T w, string funcPath_, WAVE lineMark] AddTraceFunctions(st
 	for(i = 0; i < numFunc; i += 1)
 		fullFuncName = UTF_Basics#getFullFunctionName(err, wFuncList[i], procWin)
 		if(err)
-			printf "Unable to retrieve full function name for %s in procedure %s.\r", wFuncList[i], procWin
-			printf "Is procedure file %s missing a #pragma ModuleName=<name> ?!?.\r", procWin
+			sprintf msg, "Unable to retrieve full function name for %s in procedure %s.", wFuncList[i], procWin
+			UTF_Reporting#UTF_PrintStatusMessage(msg)
+			sprintf msg, "Is procedure file %s missing a #pragma ModuleName=<name> ?!?.", procWin
+			UTF_Reporting#UTF_PrintStatusMessage(msg)
 			continue
 		endif
 		UTF_Basics#AddFunctionTagWave(fullFuncName)
@@ -852,7 +854,7 @@ static Function AnalyzeTracingResult()
 	variable colR, colG, colB
 	string msg
 
-	printf "Generating coverage output."
+	UTF_Reporting#UTF_PrintStatusMessage("Generating coverage output.")
 
 	TUFXOP_GetStorage/N="IUTF_Testrun" wrefMain
 	if(V_flag)
@@ -981,10 +983,9 @@ static Function AnalyzeTracingResult()
 	MatrixOP/FREE statLines = sum(col(statistics, STAT_LINES))
 	MatrixOP/FREE statCovered = sum(col(statistics, STAT_COVERED))
 	sprintf statOut, "Code lines: %d\rLines covered : %d\rCoverage: %.1f%%\r", statLines[0], statCovered[0], statCovered[0] * 100 / statLines[0]
-	fprintf -1, "%s", statOut
 
-	printf "Done.\r"
-	printf "%s", statOut
+	UTF_Reporting#UTF_PrintStatusMessage("Done.")
+	UTF_Reporting#UTF_PrintStatusMessage(statOut)
 End
 
 #endif

--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -258,7 +258,7 @@ End
 /// We return a fixed string if it is null and limit its size so that it can be used in a sprintf statement using plain
 /// "%s". We also do that for IP9, where this limit does not exist anymore, to have a consistent output across all IP
 /// versions.
-static Function/S PrepareStringForOut(str, [maxLen])
+threadsafe Function/S IUTF_PrepareStringForOut(str, [maxLen])
 	string &str
 	variable maxLen
 


### PR DESCRIPTION
Most calls to printf or fprintf are changed to UTF_Reporting#UTF_PrintStatusMessage. This function also ensures that the message is printed to stdout.

UTF_Reporting#UTF_PrintStatusMessage is now marked as threadsafe.

Close #329

## Dependency

- [x] PR #327 