### PR TITLE
unit-testing-autorun.ipf: Add missing ModuleName pragma

### DIFF
--- a/procedures/unit-testing-autorun.ipf
+++ b/procedures/unit-testing-autorun.ipf
@@ -2,6 +2,7 @@
 #pragma rtFunctionErrors=1
 #pragma version=1.08
 #pragma TextEncoding="UTF-8"
+#pragma ModuleName=UTF_AutoRun
 
 // Licensed under 3-Clause BSD, see License.txt
 


### PR DESCRIPTION
This allows to use code coverage determination to be used. Without it the UTF complains that AfterFileOpenHook is static and, without a module name, unaccessible.