### PR TITLE
GetWavePointer_Impl: Fix return memory address

### DIFF
--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -477,9 +477,9 @@ threadsafe static Function/S GetWavePointer_Impl(wv)
 	WAVE ref = refWave
 
 #if IgorVersion() >= 7.0
-	sprintf str, "0x08%x", ref[0]; err = GetRTError(1)
+	sprintf str, "%#08X", ref[0]; err = GetRTError(1)
 #else
-	sprintf str, "0x08%x", ref[0]
+	sprintf str, "%#08X", ref[0]
 #endif
 
 	return str


### PR DESCRIPTION
We don't want to prefix it with 08 but instead we want to have 08 as precision which must stand *after* the percent sign.

While at it we also leverage the power of # and capital X to get a capital 0X prefix.

Bug introduced in b7bb12a4 (AreWavesEqual creates descriptive message in WAVE_DATA mode, 2021-03-04).