### PR TITLE
Fix EnsureLargeEnoughWaveSimple for any index

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -76,7 +76,6 @@ static StrConstant BACKGROUNDMONTASK   = "UTFBackgroundMonitor"
 static StrConstant BACKGROUNDMONFUNC   = "UTFBackgroundMonitor"
 static StrConstant BACKGROUNDINFOSTR   = ":UNUSED_FOR_REENTRY:"
 static Constant IP8_PRINTF_STR_MAX_LENGTH = 2400
-static Constant WAVECHUNK_SIZE = 1024
 
 static StrConstant DGEN_VAR_TEMPLATE = "v"
 static StrConstant DGEN_STR_TEMPLATE = "s"
@@ -632,7 +631,7 @@ static Function/WAVE GetFailedProcWave()
 		return wv
 	endif
 
-	Make/T/N=(WAVECHUNK_SIZE) dfr:$name/WAVE=wv
+	Make/T/N=(IUTF_WAVECHUNK_SIZE) dfr:$name/WAVE=wv
 	SetNumberInWaveNote(wv, TC_SUMMARY_LENGTH_KEY, 0)
 
 	return wv

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -180,7 +180,7 @@ static Function/WAVE GetFunctionTagWaves()
 	return wv
 End
 
-/// @brief Simple function to automatically increase the wave size by a chunk in the rows dimension
+/// @brief Automatically increase the wave row size if required to fit the specified index.
 ///        The actual (filled) wave size is not tracked, the caller has to do that.
 ///        Returns 1 if the wave was resized, 0 if it was not resized
 static Function EnsureLargeEnoughWaveSimple(wv, indexShouldExist)
@@ -189,16 +189,50 @@ static Function EnsureLargeEnoughWaveSimple(wv, indexShouldExist)
 	variable indexShouldExist
 
 	variable size = DimSize(wv, UTF_ROW)
+	variable targetSize
 
 	if(indexShouldExist < size)
 		return 0
 	endif
 
-	if(size < WAVECHUNK_SIZE)
-		Redimension/N=(WAVECHUNK_SIZE, -1, -1, -1) wv
+	// the wave is smaller than any usable chunk
+	if(size < IUTF_WAVECHUNK_SIZE && indexShouldExist < IUTF_WAVECHUNK_SIZE)
+		targetSize = IUTF_WAVECHUNK_SIZE
+	// exponential sizing for smaller waves as this behave asymptotic better
+	elseif(indexShouldExist < IUTF_BIGWAVECHUNK_SIZE)
+		// Calculate the target size. This is a shortcut because we need most times to increase the
+		// size only for a small amount and a single multiplication is faster then the complex
+		// operation below.
+		targetSize = size * 2
+		if(targetSize <= indexShouldExist)
+			// target size: n
+			// indexShouldExist: m
+			// chunk size: c
+			// exponent: e
+			//
+			// n = c * 2 ^ e >= m + 1
+			// => 2 ^ e >= (m + 1)/c
+			// => e >= log_2((m + 1) / c)
+			// => e = ceil(log_2((m + 1) / c))
+			// => n = c * 2 ^ ceil(log_2((m + 1) / c)) = c * 2 ^ ceil(ln((m + 1) / c) / ln(2))
+			targetSize = IUTF_WAVECHUNK_SIZE * 2 ^ ceil(ln((indexShouldExist + 1) / IUTF_WAVECHUNK_SIZE) / ln(2))
+		endif
+	// linear sizing for really large waves with high system memory impact. This is to reduce system
+	// memory stress.
 	else
-		Redimension/N=(size * 2, -1, -1, -1) wv
+		// target size: n
+		// indexShouldExist: m
+		// big chunk size: c
+		// multiplicator: a
+		//
+		// n = c * a >= m + 1
+		// => a >= (m + 1) / c
+		// => a = ceil((m + 1) / c)
+		// => n = c * ceil((m + 1) / c)
+		targetSize = IUTF_BIGWAVECHUNK_SIZE * ceil((indexShouldExist + 1) / IUTF_BIGWAVECHUNK_SIZE)
 	endif
+
+	Redimension/N=(targetSize, -1, -1, -1) wv
 
 	return 1
 End

--- a/procedures/unit-testing-constants.ipf
+++ b/procedures/unit-testing-constants.ipf
@@ -35,6 +35,10 @@ Constant REQUIRE_MODE   = 0x07 // == OUTPUT_MESSAGE | INCREASE_ERROR | ABORT_FUN
 ///@}
 
 Constant IUTF_WAVECHUNK_SIZE = 1024
+// The size when a wave is considered as really big. After this point the sizes of chunks are
+// handled differently because of the large impact to system memory.
+// This number is 512 * 1024 * 1024 (= 512 MiB)
+Constant IUTF_BIGWAVECHUNK_SIZE = 536870912
 
 ///@endcond // HIDDEN_SYMBOL
 

--- a/procedures/unit-testing-constants.ipf
+++ b/procedures/unit-testing-constants.ipf
@@ -34,6 +34,8 @@ Constant CHECK_MODE     = 0x03 // == OUTPUT_MESSAGE | INCREASE_ERROR
 Constant REQUIRE_MODE   = 0x07 // == OUTPUT_MESSAGE | INCREASE_ERROR | ABORT_FUNCTION
 ///@}
 
+Constant IUTF_WAVECHUNK_SIZE = 1024
+
 ///@endcond // HIDDEN_SYMBOL
 
 /// @addtogroup AssertionFlags

--- a/tests/Various.ipf
+++ b/tests/Various.ipf
@@ -582,6 +582,35 @@ static Function TC_WaveName()
 
 End
 
+static Function TC_WaveCapacity()
+	variable size
+
+	INFO("test small waves")
+	Make/FREE/N=50 wv
+	UTF_Basics#EnsureLargeEnoughWaveSimple(wv, 100)
+	size = DimSize(wv, UTF_ROW)
+	CHECK_EQUAL_VAR(IUTF_WAVECHUNK_SIZE, size)
+
+	INFO("test small increment")
+	MAKE/FREE/N=(IUTF_WAVECHUNK_SIZE * 2) wv
+	UTF_Basics#EnsureLargeEnoughWaveSimple(wv, IUTF_WAVECHUNK_SIZE * 2)
+	size = DimSize(wv, UTF_ROW)
+	CHECK_EQUAL_VAR(IUTF_WAVECHUNK_SIZE * 4, size)
+
+	INFO("test big jump")
+	MAKE/FREE/N=(IUTF_WAVECHUNK_SIZE) wv
+	UTF_Basics#EnsureLargeEnoughWaveSimple(wv, IUTF_WAVECHUNK_SIZE * 16 - 1)
+	size = DimSize(wv, UTF_ROW)
+	CHECK_EQUAL_VAR(IUTF_WAVECHUNK_SIZE * 16, size)
+
+	// I am sorry for breaking your test setup
+	INFO("test heavy load")
+	MAKE/FREE/N=(IUTF_BIGWAVECHUNK_SIZE) wv
+	UTF_Basics#EnsureLargeEnoughWaveSimple(wv, IUTF_BIGWAVECHUNK_SIZE * 2 + 1)
+	size = DimSize(wv, UTF_ROW)
+	CHECK_EQUAL_VAR(IUTF_BIGWAVECHUNK_SIZE * 3, size)
+End
+
 static Function TEST_SUITE_END_OVERRIDE(name)
 	string name
 

--- a/tests/Various.ipf
+++ b/tests/Various.ipf
@@ -572,12 +572,14 @@ static Function TC_WaveName()
 
 	Make/FREE unnamedFreeWave
 	str = UTF_UTILS#GetWaveNameInDFStr(unnamedFreeWave)
-	CHECK(GrepString(str, "^_free_ \\(0x[0-9a-f]+\\)$"))
+	INFO("name: \"%s\"", s1 = str)
+	CHECK(GrepString(str, "^_free_ \\(0[xX][0-9a-fA-F]+\\)$"))
 
 #if IgorVersion() >= 9.0
 	Make/FREE=1 namedFreeWave
 	str = UTF_Utils#GetWaveNameInDFStr(namedFreeWave)
-	CHECK(GrepString(str, "^namedFreeWave \\(0x[0-9a-f]+\\)$"))
+	INFO("name: \"%s\"", s1 = str)
+	CHECK(GrepString(str, "^namedFreeWave \\(0[xX][0-9a-fA-F]+\\)$"))
 #endif
 
 End


### PR DESCRIPTION
The old implementation does only increase the size of the wave one time
if the requested index is outside the capacity of the wave. This is okay
for smaller indexes but will return a too small wave if the requested
index is way larger than the current capacity of the wave.

This fixes the implementation in that way that it always calculates the
next suitable size that fits the requested index and resizes the wave
to always fit the requested index. This also includes a special logic to
use exponential growth with better asymptotical behavior for smaller
wave sizes and linear growth if the wave has a size that could have a
large impact on system memory.

With this EnsureLargeEnoughWaveSimple can no longer considered as
"simple" but the name is kept for compability. The documentation has
been updated.