### PR TITLE
Use lowercase pointer names

### DIFF
--- a/procedures/unit-testing-utils.ipf
+++ b/procedures/unit-testing-utils.ipf
@@ -477,9 +477,9 @@ threadsafe static Function/S GetWavePointer_Impl(wv)
 	WAVE ref = refWave
 
 #if IgorVersion() >= 7.0
-	sprintf str, "%#08X", ref[0]; err = GetRTError(1)
+	sprintf str, "%#08x", ref[0]; err = GetRTError(1)
 #else
-	sprintf str, "%#08X", ref[0]
+	sprintf str, "%#08x", ref[0]
 #endif
 
 	return str

--- a/tests/Various.ipf
+++ b/tests/Various.ipf
@@ -573,13 +573,13 @@ static Function TC_WaveName()
 	Make/FREE unnamedFreeWave
 	str = UTF_UTILS#GetWaveNameInDFStr(unnamedFreeWave)
 	INFO("name: \"%s\"", s1 = str)
-	CHECK(GrepString(str, "^_free_ \\(0[xX][0-9a-fA-F]+\\)$"))
+	CHECK(GrepString(str, "^_free_ \\(0x[0-9a-f]+\\)$"))
 
 #if IgorVersion() >= 9.0
 	Make/FREE=1 namedFreeWave
 	str = UTF_Utils#GetWaveNameInDFStr(namedFreeWave)
 	INFO("name: \"%s\"", s1 = str)
-	CHECK(GrepString(str, "^namedFreeWave \\(0[xX][0-9a-fA-F]+\\)$"))
+	CHECK(GrepString(str, "^namedFreeWave \\(0x[0-9a-f]+\\)$"))
 #endif
 
 End


### PR DESCRIPTION
b3ca346 (GetWavePointer_Impl: Fix return memory address, 2022-12-20) has
fixed the output of the pointer names but also changed it to upper case
which made it less readable for the user.

Close #358