### PR TITLE
Fix: Show INFO() for CHECK_EQUAL_WAVE()

### DIFF
--- a/procedures/unit-testing-assertion-wrappers.ipf
+++ b/procedures/unit-testing-assertion-wrappers.ipf
@@ -718,16 +718,16 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 	endif
 
 	result = WaveExists(wv1)
-	EvaluateResults(result, "Assumption that the first wave (wv1) exists", flags)
 
 	if(!result)
+		EvaluateResults(0, "Assumption that the first wave (wv1) exists", flags)
 		return NaN
 	endif
 
 	result = WaveExists(wv2)
-	EvaluateResults(result, "Assumption that the second wave (wv2) exists", flags)
 
 	if(!result)
+		EvaluateResults(0, "Assumption that the second wave (wv2) exists", flags)
 		return NaN
 	endif
 


### PR DESCRIPTION
The function EQUAL_WAVE_WRAPPER() contains multiple calls to
EvaluateResults() which clear up the AssertionInfo state after its call.
This yield to this unexpected behavior if the first call cleared the
information and the second call need it for output.

To prevent this there are two options:

1. Call "return NaN" after the call to EvaluateResults()
2. Call EvaluateResults() with "cleanupInfo = 0" and call
   UTF_Basics#CleanupInfoMsg() at the end.

Close #368