### PR TITLE
CI: Fix large required job number

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,6 +174,38 @@ deployment_staging:
   needs:
     - documentation
 
+deployment_wait_testing:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: on_success
+  tags:
+    - debian, docker
+  image:
+    name: ${CI_REGISTRY}/internal/docker-utils:latest
+  script:
+    - echo "this job does nothing except waiting for testing to finish"
+  needs:
+    - job: testing
+      artifacts: false
+
+deployment_wait_testing_nightly:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: on_success
+  tags:
+    - debian, docker
+  image:
+    name: ${CI_REGISTRY}/internal/docker-utils:latest
+  script:
+    - echo "this job does nothing except waiting for testing to finish"
+  needs:
+    - job: testing_nightly
+      artifacts: false
+
 deployment:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
@@ -192,9 +224,7 @@ deployment:
     - lftp -e "mirror --reverse -n -e build/html /igor-unit-testing-framework; bye" -u $FTP_USER_DOCS,$FTP_PW_DOCS byte-physics.de
   needs:
     - documentation
-    - job: testing
-      artifacts: false
-    - job: testing_nightly
-      artifacts: false
+    - deployment_wait_testing
+    - deployment_wait_testing_nightly
     - job: pre-commit
       artifacts: false


### PR DESCRIPTION
Gitlab does only allow 50 jobs in its need list. After the changes in 05a47a7 (Include test results test in CI, 2022-12-08) the job "deployment" has now 54 jobs in its need list. This fix solved this issue by adding some dummy tests which purpose is only to wait for the test matrix to complete.

Close #379