### PR TITLE
Require optional function parameter for reentry

### DIFF
--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -1669,7 +1669,7 @@ static Function CallTestCase(s, reentry)
 	STRUCT IUTF_mData mData
 
 	variable wType0, wType1, wRefSubType, err, tcIndex
-	string func, msg, dgenFuncName, origTCName
+	string func, msg, dgenFuncName, origTCName, funcInfo
 
 	WAVE/T testRunData = GetTestRunData()
 	tcIndex = s.i
@@ -1678,6 +1678,14 @@ static Function CallTestCase(s, reentry)
 		DFREF dfr = GetPackageFolder()
 		SVAR reentryFuncName = dfr:BCKG_ReentryFunc
 		func = reentryFuncName
+
+		// Require only optional parameter
+		funcInfo = FunctionInfo(func)
+		if (NumberByKey("N_PARAMS", funcInfo) != NumberByKey("N_OPT_PARAMS", funcInfo))
+			sprintf msg, "Reentry functions require all its parameter as optional: \"%s\"", func
+			UTF_Reporting#ReportErrorAndAbort(msg)
+		endif
+
 		sprintf msg, "Entering reentry \"%s\"", func
 		UTF_Reporting#UTF_PrintStatusMessage(msg)
 	else


### PR DESCRIPTION
The function parameter are now checked if they are all optional as in the test cases. This fixes the loose function signature check in Igor 6 like it was done in 085e3d3 (Require optional parameter for test methods, 2022-10-07).

Close #270