### PR TITLE
Use cached home path for accessing files

### DIFF
--- a/procedures/unit-testing-autorun.ipf
+++ b/procedures/unit-testing-autorun.ipf
@@ -18,13 +18,17 @@ End
 ///
 /// @returns one of @ref AutorunModes
 Function GetAutorunMode()
-	GetFileFolderInfo/Q/Z/P=home "DO_AUTORUN.TXT"
+	string path
+
+	path = UTF_Utils_Paths#AtHome("DO_AUTORUN.TXT")
+	GetFileFolderInfo/Q/Z path
 
 	if(!V_flag)
 		return AUTORUN_FULL
 	endif
 
-	GetFileFolderInfo/Q/Z/P=home "DO_AUTORUN_PLAIN.TXT"
+	path = UTF_Utils_Paths#AtHome("DO_AUTORUN_PLAIN.TXT")
+	GetFileFolderInfo/Q/Z path
 
 	if(!V_flag)
 		return AUTORUN_PLAIN
@@ -134,13 +138,7 @@ Function SaveHistoryLog()
 		return NaN
 	endif
 
-	PathInfo home
-	historyLog = getUnusedFileName(S_path + historyLog)
-	if(UTF_Utils#IsEmpty(historyLog))
-		sprintf msg, "Error: Unable to determine unused file name for History Log output in path %s !", S_path
-		UTF_Reporting#UTF_PrintStatusMessage(msg)
-		return NaN
-	endif
+	historyLog = UTF_Utils_Paths#AtHome(historyLog, unusedName = 1)
 
-	SaveNoteBook/S=3/P=home HistoryCarbonCopy as historyLog
+	SaveNoteBook/S=3 HistoryCarbonCopy as historyLog
 End

--- a/procedures/unit-testing-basics.ipf
+++ b/procedures/unit-testing-basics.ipf
@@ -273,39 +273,6 @@ Function/DF GetPackageFolder()
 	return dfr
 End
 
-/// Returns 0 if the file exists, !0 otherwise
-static Function FileNotExists(fname)
-	string fname
-
-	GetFileFolderInfo/Q/Z fname
-	return V_Flag
-End
-
-/// returns a non existing file name an empty string
-Function/S getUnusedFileName(fname)
-	string fname
-
-	variable count
-	string fn, fnext, fnn
-
-	if (FileNotExists(fname))
-		return fname
-	endif
-	fname = ParseFilePath(5, fname, "\\", 0, 0)
-	fnext = "." + ParseFilePath(4, fname, "\\", 0, 0)
-	fnn = RemoveEnding(fname, fnext)
-
-	count = -1
-	do
-		count += 1
-		sprintf fn, "%s_%03d%s", fnn, count, fnext
-	while(!FileNotExists(fn) && count < 999)
-	if(!FileNotExists(fn))
-		return ""
-	endif
-	return fn
-End
-
 /// Creates a global with the allowed variable names for mmd data tests and returns the value
 static Function/S GetMMDAllVariablesList()
 
@@ -2402,6 +2369,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 
 	else
 		// no early return/abort above this point
+		UTF_Utils_Paths#ClearHomePath()
 		DFREF dfr = GetPackageFolder()
 		string/G dfr:baseFilenameOverwrite = SelectString(fixLogName, "", FIXED_LOG_FILENAME)
 		ClearTestSetupWaves()
@@ -2424,8 +2392,9 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 		s.tracingEnabled = !ParamIsDefault(traceWinList) && !UTF_Utils#IsEmpty(traceWinList)
 
 		if(s.enableJU || s.enableTAP || s.tracingEnabled)
-			PathInfo home
-			if(!V_flag)
+			// the path is only needed locally
+			msg = UTF_Utils_Paths#GetHomePath()
+			if(UTF_Utils#IsEmpty(msg))
 				UTF_Reporting#ReportError("Error: Please Save experiment first.")
 				return NaN
 			endif

--- a/procedures/unit-testing-junit.ipf
+++ b/procedures/unit-testing-junit.ipf
@@ -256,21 +256,14 @@ static Function JU_WriteOutput()
 #else
 	out = JU_UTF8Filter(out)
 #endif
-	PathInfo home
-	juFileName = getUnusedFileName(S_path + "JU_" + GetBaseFilename() + ".xml")
-	if(UTF_Utils#IsEmpty(juFileName))
-		sprintf msg, "Error: Unable to determine unused file name for JUNIT output in path %s !", S_path
-		UTF_Reporting#UTF_PrintStatusMessage(msg)
-		return NaN
-	endif
+	juFileName = UTF_Utils_Paths#AtHome("JU_" + GetBaseFilename() + ".xml", unusedName = 1)
 
-	open/Z/P=home fnum as juFileName
+	open/Z fnum as juFileName
 	if(!V_flag)
 		fBinWrite fnum, out
 		close fnum
 	else
-		PathInfo home
-		sprintf msg, "Error: Could not create JUNIT output file at %s", S_path + juFileName
+		sprintf msg, "Error: Could not create JUNIT output file at %s", juFileName
 		UTF_Reporting#UTF_PrintStatusMessage(msg)
 	endif
 End

--- a/procedures/unit-testing-tap.ipf
+++ b/procedures/unit-testing-tap.ipf
@@ -189,19 +189,11 @@ static Function TAP_Write()
 	string filename, s, msg
 	variable caseCount = 1
 
-	filename = "tap_" + GetBaseFilename() + ".log"
-	PathInfo home
-	filename = getUnusedFileName(S_path + filename)
-	if(!strlen(filename))
-		sprintf msg, "Error: Unable to determine unused file name for TAP output in path %s !", S_path
-		UTF_Reporting#UTF_PrintStatusMessage(msg)
-		return NaN
-	endif
+	filename = UTF_Utils_Paths#AtHome("tap_" + GetBaseFilename() + ".log", unusedName = 1)
 
-	open/Z/P=home fnum as filename
+	open/Z fnum as filename
 	if(V_flag)
-		PathInfo home
-		sprintf msg, "Error: Could not create TAP output file at %s", S_path + filename
+		sprintf msg, "Error: Could not create TAP output file at %s", filename
 		UTF_Reporting#UTF_PrintStatusMessage(msg)
 		return NaN
 	endif

--- a/procedures/unit-testing-tracing.ipf
+++ b/procedures/unit-testing-tracing.ipf
@@ -242,7 +242,7 @@ static Function SetupTraceProcedures(string procWinList, string traceOptions)
 		endif
 	endfor
 
-	Save/P=home/O/M="\n"/J markLinesProc as INSTRUDATA_FILENAME
+	Save/O/M="\n"/J markLinesProc as (UTF_Utils_Paths#AtHome(INSTRUDATA_FILENAME))
 
 	DFREF dfr = GetPackageFolder()
 	string/G dfr:$GLOBAL_IPROCLIST = iProcList
@@ -852,7 +852,7 @@ static Function AnalyzeTracingResult()
 	string funcList, fullFuncName, procWin, funcPath, procText, prefix, line, fName, wName, procLine, NBSpace, tabReplace, statOut
 	string procLineFormat
 	variable colR, colG, colB
-	string msg
+	string msg, instruDataPath
 
 	UTF_Reporting#UTF_PrintStatusMessage("Generating coverage output.")
 
@@ -872,12 +872,13 @@ static Function AnalyzeTracingResult()
 		MultiThread logdata += logdataThread[p][q][r]
 	endfor
 
-	GetFileFolderInfo/P=home/Z/Q INSTRUDATA_FILENAME
+	instruDataPath = UTF_Utils_Paths#AtHome(INSTRUDATA_FILENAME)
+	GetFileFolderInfo/Z/Q instruDataPath
 	if(V_flag || !V_IsFile)
 		UTF_Reporting#ReportErrorAndAbort("Error as the instrumentation data does not exist anymore.")
 	endif
 
-	LoadWave/P=home/J/K=1/O/Q/M/N=iutf_instrumented_data INSTRUDATA_FILENAME
+	LoadWave/J/K=1/O/Q/M/N=iutf_instrumented_data instruDataPath
 	if(V_flag != 1)
 		UTF_Reporting#ReportErrorAndAbort("Error when loading instrumentation data.")
 	endif
@@ -977,7 +978,7 @@ static Function AnalyzeTracingResult()
 			Notebook NBTracedData selection={startOfPrevParagraph, endOfPrevParagraph}, textRGB=(0 * 0xff, 32  * 0xff, 128  * 0xff)
 		endfor
 		fName = procWin[0, strlen(procWin) - 5] + ".htm"
-		SaveNotebook/O/P=home/S=5/H={"UTF-8", 0xFFFF, 0xFFFF, 0, 0, 32} NBTracedData as fName
+		SaveNotebook/O/S=5/H={"UTF-8", 0xFFFF, 0xFFFF, 0, 0, 32} NBTracedData as (UTF_Utils_Paths#AtHome(fName))
 	endfor
 
 	MatrixOP/FREE statLines = sum(col(statistics, STAT_LINES))

--- a/procedures/unit-testing-utils-paths.ipf
+++ b/procedures/unit-testing-utils-paths.ipf
@@ -1,0 +1,98 @@
+#pragma rtGlobals=3
+#pragma rtFunctionErrors=1
+#pragma version=1.09
+#pragma TextEncoding="UTF-8"
+#pragma ModuleName=UTF_Utils_Paths
+
+///@cond HIDDEN_SYMBOL
+
+/// @brief Clears the current stored home path. The next call to GetHomePath() will return the
+// current home path.
+static Function ClearHomePath()
+	DFREF dfr = GetPackageFolder()
+	KillStrings/Z dfr:homePath
+End
+
+/// @brief Returns the home path at the start of the execution of RunTest. If this experiment wasn't
+/// saved at this point it will return an empty string.
+static Function/S GetHomePath()
+	DFREF dfr = GetPackageFolder()
+	SVAR/Z/SDFR=dfr homePath
+
+	if(SVAR_Exists(homePath))
+		return homePath
+	endif
+
+	PathInfo home
+	if(V_flag)
+		string/G dfr:homePath = S_path
+		return S_path
+	else
+		string/G dfr:homePath = ""
+		return ""
+	endif
+End
+
+/// @brief Get the full path of a file at the cached home directory
+///
+/// @param fileName  The file name that need to be located in the home directory
+/// @param unusedName  (optional, default 0=disabled) If set to 1 it will search for an unused file
+///                    name in the home directory with the same pattern as fileName.
+///                    If no unused file name could be found this function will abort the execution.
+///
+/// @returns The full file path
+static Function/S AtHome(fileName, [unusedName])
+	string fileName
+	variable unusedName
+
+	string result, msg
+
+	unusedName = ParamIsDefault(unusedName) ? 0 : !!unusedName
+
+	result = GetHomePath() + fileName
+
+	if(unusedName)
+		result = getUnusedFileName(result)
+		if(UTF_Utils#IsEmpty(result))
+			sprintf msg, "Cannot determine unused file for %s at home directory", fileName
+			UTF_Reporting#ReportErrorAndAbort(msg)
+		endif
+	endif
+
+	return result
+End
+
+/// Returns 0 if the file exists, !0 otherwise
+static Function FileNotExists(fname)
+	string fname
+
+	GetFileFolderInfo/Q/Z fname
+	return V_Flag
+End
+
+/// returns a non existing file name an empty string
+static Function/S getUnusedFileName(fname)
+	string fname
+
+	variable count
+	string fn, fnext, fnn
+
+	if (FileNotExists(fname))
+		return fname
+	endif
+	fname = ParseFilePath(5, fname, "\\", 0, 0)
+	fnext = "." + ParseFilePath(4, fname, "\\", 0, 0)
+	fnn = RemoveEnding(fname, fnext)
+
+	count = -1
+	do
+		count += 1
+		sprintf fn, "%s_%03d%s", fnn, count, fnext
+	while(!FileNotExists(fn) && count < 999)
+	if(!FileNotExists(fn))
+		return ""
+	endif
+	return fn
+End
+
+///@endcond // HIDDEN_SYMBOL

--- a/procedures/unit-testing.ipf
+++ b/procedures/unit-testing.ipf
@@ -19,6 +19,7 @@
 #include "unit-testing-reporting"
 #include "unit-testing-reporting-control"
 #include "unit-testing-utils"
+#include "unit-testing-utils-paths"
 #include "unit-testing-utils-strings"
 #include "unit-testing-utils-textgrid"
 #include "unit-testing-utils-vector"


### PR DESCRIPTION
At the start of RunTest the current home directory of the experiment file is fetched and cached in a global string. If for some reasons a test case changed to current home directory (for example storing the experiment file elsewhere) all UTF functions will still use the old home directory.

Close #287