### PR TITLE
Do wave leak checking only once for each test case

### DIFF
--- a/procedures/igortest-hooks.ipf
+++ b/procedures/igortest-hooks.ipf
@@ -37,11 +37,13 @@ End
 
 /// @brief Execute the provided user hook and catches all runtime errors. If the name of the hook
 /// function doesn't end in "_OVERRIDE" this hook will be considered as prototype and won't be
-/// executed. The return is still 0 as if no error happened.
+/// executed.
 ///
 /// @param name      name of the test run/suite/case
 /// @param userHook  the function reference to the user hook
 /// @param procWIn   name of the procedure window
+/// @return          Returns 1 if a user hook was executed and 0 if no user hook exists or an
+///                  invalid configuration was found.
 static Function ExecuteUserHook(name, userHook, procWin, level)
 	FUNCREF USER_HOOK_PROTO userHook
 	string name, procWin
@@ -52,7 +54,7 @@ static Function ExecuteUserHook(name, userHook, procWin, level)
 	string hookName = StringByKey("Name", FuncRefInfo(userHook))
 
 	if(!StringMatch(hookName, "*_OVERRIDE"))
-		return NaN
+		return 0
 	endif
 
 	switch(level)
@@ -69,7 +71,7 @@ static Function ExecuteUserHook(name, userHook, procWin, level)
 		default:
 			sprintf errorMessage, "Unknown hook level: %d", level
 			IUTF_Reporting#ReportErrorAndAbort(errorMessage)
-			return NaN
+			return 0
 	endswitch
 
 	StartWaveTracking(name)
@@ -103,8 +105,10 @@ static Function ExecuteUserHook(name, userHook, procWin, level)
 		default:
 			sprintf errorMessage, "Unknown hook level: %d", level
 			IUTF_Reporting#ReportErrorAndAbort(errorMessage)
-			return NaN
+			return 0
 	endswitch
+
+	return 1
 End
 
 /// @brief Execute the builtin and user hooks


### PR DESCRIPTION
In the previous implementation was a wave leak check performed for each test
case and each user hook. Igortest does only check weak leaks once for a test
case in combination with its test case begin and end hook now. There is no
longer a separate weak leak check for a user hook, and test and test suite begin
and end hooks no longer have a weak leak check at all.

If a wave leak was found it will be reported as part of the test case user end
hook or if such does not exists to the test case itself.

The tests has been adapted to the changes and a new test case has been added
that check a scenario without any user hooks. The new test cases eliminate the
existing user end hook in its reentry function and remove the need of an
additional test file.

Close #497