### PR TITLE
EvaluteRTE: Correctly report AbortOnValue aborts with negative abort codes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
   hooks:
   - id: forbid-bidi-controls
 - repo: https://github.com/fsfe/reuse-tool
-  rev: v1.0.0
+  rev: v6.2.0
   hooks:
   - id: reuse

--- a/procedures/igortest-basics.ipf
+++ b/procedures/igortest-basics.ipf
@@ -453,15 +453,14 @@ static Function EvaluateRTE(err, errmessage, abortCode, funcName, funcType, proc
 				IUTF_Reporting#AddError(str, IUTF_STATUS_ERROR)
 				break
 			default:
+				if(abortCode != 0)
+					sprintf str, "Encountered \"AbortOnValue\" Code %d in %s \"%s\" (%s)", abortCode, funcTypeString, funcName, procWin
+					IUTF_Reporting#AddFailedSummaryInfo(str)
+					IUTF_Reporting#AddError(str, IUTF_STATUS_ERROR)
+				endif
 				break
 		endswitch
 		message += str
-		if(abortCode > 0)
-			sprintf str, "Encountered \"AbortOnValue\" Code %d in %s \"%s\" (%s)", abortCode, funcTypeString, funcName, procWin
-			IUTF_Reporting#AddFailedSummaryInfo(str)
-			IUTF_Reporting#AddError(str, IUTF_STATUS_ERROR)
-			message += str
-		endif
 	endif
 
 	IUTF_Reporting#ReportError(message, incrGlobalErrorCounter = 0)

--- a/procedures/igortest-tap.ipf
+++ b/procedures/igortest-tap.ipf
@@ -8,7 +8,6 @@ static StrConstant TAP_LINEEND_STR = "\n"
 
 /// @brief returns 1 if all test cases are marked as SKIP and TAP is enabled, zero otherwise
 ///
-/// @param testCaseList list of function names
 /// @returns 1 if all test cases are marked as SKIP and TAP is enabled, zero otherwise
 static Function TAP_AreAllFunctionsSkip()
 

--- a/tests/UnitTests/Utils/AbortedTests.ipf
+++ b/tests/UnitTests/Utils/AbortedTests.ipf
@@ -1,0 +1,31 @@
+#pragma rtGlobals=3
+#pragma TextEncoding="UTF-8"
+#pragma rtFunctionErrors=1
+#pragma version=1.10
+#pragma ModuleName=TEST_Aborted
+
+static Function TEST_CASE_BEGIN_OVERRIDE(string testcase)
+
+	variable/G root:historyRef = CaptureHistoryStart()
+End
+
+static Function TEST_CASE_END_OVERRIDE(string testcase)
+
+	NVAR/SDFR=root: historyRef
+	string/G root:history = CaptureHistory(historyRef, 1)
+End
+
+// IUTF_EXPECTED_FAILURE
+static Function AbortWithNegativeValue()
+
+	AbortOnValue 1, -10
+End
+
+static Function EvaluateAbortWithNegativeValue()
+
+	SVAR/SDFR=root: history
+
+	INFO("%s", s0 = history)
+
+	CHECK_GE_VAR(strsearch(history, "Encountered \"AbortOnValue\" Code -10 in test case \"TEST_Aborted#AbortWithNegativeValue\" (AbortedTests.ipf)", 0), 0)
+End

--- a/tests/UnitTests/main.ipf
+++ b/tests/UnitTests/main.ipf
@@ -10,6 +10,7 @@
 #include ":Tracing:ComplexityTests"
 #include ":Utils:PathsTests"
 #include ":Utils:StringsTests"
+#include ":Utils:AbortedTests"
 
 #undef UTF_ALLOW_TRACING
 #if Exists("TUFXOP_Version")


### PR DESCRIPTION
We need to assume that all error codes not being -1, -2, -3, -4 are from AbortOnValue as we can't differentiate them. This now correctly reports AbortOnValue aborts with negative abort codes.

Broken since a7ab54c (More detailed RTE error message, 2017-03-07). It did not help that the Igor Pro documentation is also wrong in this regard.